### PR TITLE
Fix for SR-56

### DIFF
--- a/katsdpsigproc/opencl.py
+++ b/katsdpsigproc/opencl.py
@@ -123,6 +123,14 @@ class Device(object):
                 ans.append(Device(device))
         return ans
 
+    @classmethod
+    def get_devices_by_platform(cls):
+        """Return a list of all devices, with a sub-list per platform."""
+        ans = []
+        for platform in pyopencl.get_platforms():
+            ans.append([Device(device) for device in platform.get_devices()])
+        return ans
+
 class Context(object):
     """Abstraction of an OpenCL context"""
     def __init__(self, pyopencl_context):


### PR DESCRIPTION
This to fix environment variable compatibility with PyOpenCL. PyOpenCL allows one to set the variable PYOPENCL_CTX to either X or X:Y to select platform X or platform X, device Y (both 0-based indices).

@sratcliffe, could you either look at this (it's pretty small) or assign someone else to?
