### PR TITLE
Improve ranking code to deal with NaNs

### DIFF
--- a/katsdpsigproc/rfi/madnz.mako
+++ b/katsdpsigproc/rfi/madnz.mako
@@ -50,8 +50,14 @@ DEVICE_FN float array_piece_get(const array_piece *self, int idx)
 }
 
 <%rank:ranker_serial class_name="ranker_abs_serial" type="float">
-    <%def name="foreach(self)">
-        for (int i = (${self})->piece.start; i < (${self})->piece.end; i++)
+    <%def name="foreach(self, start=0, stop=None)">
+        <%
+        if stop is None:
+            stop = '({0})->piece.end'.format(self)
+        else:
+            stop = '({0})->piece.start + ({1})'.format(self, stop)
+        %>
+        for (int i = (${self})->piece.start + (${start}); i < ${stop}; i++)
         {
             ${caller.body('fabs(array_piece_get(&(%s)->piece, i))' % (self,))}
         }

--- a/katsdpsigproc/rfi/madnz_t.mako
+++ b/katsdpsigproc/rfi/madnz_t.mako
@@ -23,9 +23,9 @@
 <%namespace name="rank" file="/rank.mako"/>
 
 <%rank:ranker_serial class_name="ranker_abs_serial" type="float">
-    <%def name="foreach(self)">
+    <%def name="foreach(self, start=0, stop='VT')">
         #pragma unroll
-        for (int i = 0; i < VT; i++)
+        for (int i = ${start}; i < ${stop}; i++)
         {
             ${caller.body('(%s)->values[i]' % (self,))}
         }
@@ -40,7 +40,7 @@ DEVICE_FN void ranker_abs_serial_init(
     int p = start;
     for (int i = 0; i < VT; i++)
     {
-        self->values[i] = (p < N) ? fabs(data[p]) : FLT_MAX;
+        self->values[i] = (p < N) ? fabs(data[p]) : NAN;
         p += step;
     }
 }

--- a/katsdpsigproc/test/test_rank.mako
+++ b/katsdpsigproc/test/test_rank.mako
@@ -9,8 +9,9 @@
 
 <%def name="define_rankers(type)">
 <%rank:ranker_serial class_name="ranker_serial_${type}" type="${type}">
-    <%def name="foreach(self)">
-        for (int i = 0; i < ${self}->N; i++)
+    <%def name="foreach(self, start=0, stop=None)">
+        <% if stop is None: stop = '({0})->N'.format(self) %>
+        for (int i = ${start}; i < ${stop}; i++)
         {
             ${caller.body(self + '->values[i]')}
         }

--- a/katsdpsigproc/test/test_rank.py
+++ b/katsdpsigproc/test/test_rank.py
@@ -64,7 +64,7 @@ def run_float_func(context, queue, kernel_name, data, output_size):
 class TestFindMinMaxFloat(object):
     def check_array(self, context, queue, data):
         data = np.asarray(data, dtype=np.float32)
-        expected = [np.min(data), np.max(data)]
+        expected = [np.nanmin(data), np.nanmax(data)]
         out = run_float_func(context, queue, 'test_find_min_max_float', data, 2)
         assert_equal(expected[0], out[0])
         assert_equal(expected[1], out[1])
@@ -77,6 +77,19 @@ class TestFindMinMaxFloat(object):
     def test_ordered(self, context, queue):
         data = np.sort(np.random.uniform(-10.0, 10.0, 1000))
         self.check_array(context, queue, data)
+
+    @device_test
+    def test_nan(self, context, queue):
+        self.check_array(context, queue, [-10.0, 5.5, np.nan, -20.0, np.nan])
+
+    @device_test
+    def test_all_nan(self, context, queue):
+        # Can't use check_array, because np.nanmin warns if all are NaN,
+        # and assert_equal doesn't handle NaN
+        data = np.array([np.nan, np.nan], dtype=np.float32)
+        out = run_float_func(context, queue, 'test_find_min_max_float', data, 2)
+        assert np.isnan(out[0])
+        assert np.isnan(out[1])
 
     @device_test
     def test_random(self, context, queue):


### PR DESCRIPTION
The main motivation is to allow find_max_float to work when data needs
to be padded for efficiency. Previous use cases (in the RFI code) padded
with FLT_MAX, which works fine for find_rank_float (since they're larger
than all the real data), but would have caused find_max_float to return
the padding value.

Padding is now done with NaN, and find_min_float/find_max_float use
fmin/fmax so that NaN values are ignored.
