### PR TITLE
Provide threshold_args etc to FlaggerHostFromDevice.

### DIFF
--- a/katsdpsigproc/rfi/device.py
+++ b/katsdpsigproc/rfi/device.py
@@ -791,14 +791,25 @@ class FlaggerHostFromDevice(object):
         Operation template
     command_queue : :class:`katsdpsigproc.cuda.CommandQueue` or :class:`katsdpsigproc.opencl.CommandQueue`
         Command queue for the operation
+    background_args : dict, optional
+        Extra keyword arguments to pass to the background instantiation
+    noise_est_args : dict, optional
+        Extra keyword arguments to pass to the noise estimation instantiation
+    threshold_args : dict, optional
+        Extra keyword arguments to pass to the threshold instantiation
     """
-    def __init__(self, template, command_queue):
+    def __init__(self, template, command_queue, background_args={}, noise_est_args={}, threshold_args={}):
         self.template = template
         self.command_queue = command_queue
+        self.background_args = dict(background_args)
+        self.noise_est_args = dict(noise_est_args)
+        self.threshold_args = dict(threshold_args)
 
     def __call__(self, vis):
         (channels, baselines) = vis.shape
-        fn = self.template.instantiate(self.command_queue, channels, baselines)
+        fn = self.template.instantiate(
+                self.command_queue, channels, baselines,
+                self.background_args, self.noise_est_args, self.threshold_args)
         fn.ensure_all_bound()
         fn.buffer('vis').set(self.command_queue, vis)
         fn()

--- a/katsdpsigproc/rfi/test/test_flagger.py
+++ b/katsdpsigproc/rfi/test/test_flagger.py
@@ -38,9 +38,9 @@ def check_flagger_device(transpose_noise_est, transpose_threshold, context, queu
     else:
         noise_est = device.NoiseEstMADDeviceTemplate(context, tuning={'wgsx': 8, 'wgsy': 8})
     threshold = device.ThresholdSimpleDeviceTemplate(context,
-            11.0, transpose_threshold, tuning={'wgsx': 8, 'wgsy': 8})
+            transpose_threshold, tuning={'wgsx': 8, 'wgsy': 8})
     flagger_device = device.FlaggerDeviceTemplate(background, noise_est, threshold)
-    flagger = device.FlaggerHostFromDevice(flagger_device, queue)
+    flagger = device.FlaggerHostFromDevice(flagger_device, queue, threshold_args=dict(n_sigma=11.0))
     flags = flagger(_vis)
     np.testing.assert_equal(_spikes, flags)
 


### PR DESCRIPTION
This allows failing flagger tests to be fixed (they have presumably been
failing for a long time - oops). This shouldn't affect any production
code.
