### PR TITLE
Make katsdpsigproc work on Python 3

### DIFF
--- a/katsdpsigproc/__init__.py
+++ b/katsdpsigproc/__init__.py
@@ -2,6 +2,7 @@
 
 # BEGIN VERSION CHECK
 # Get package version when locally imported from repo or via -e develop install
+from __future__ import division, print_function, absolute_import
 try:
     import katversion as _katversion
 except ImportError:

--- a/katsdpsigproc/cuda.py
+++ b/katsdpsigproc/cuda.py
@@ -4,11 +4,13 @@ the documentation for :mod:`katsdpsigproc.opencl`, which presents the same
 interfaces.
 """
 
+from __future__ import division, print_function, absolute_import
 import pycuda.driver
 import pycuda.compiler
 import pycuda.gpuarray
 import pycuda.characterize
 import numpy as np
+from six.moves import range
 
 NVCC_FLAGS = pycuda.compiler.DEFAULT_NVCC_FLAGS + ['-lineinfo']
 

--- a/katsdpsigproc/fill.py
+++ b/katsdpsigproc/fill.py
@@ -1,5 +1,6 @@
 """Fill device array with a constant value"""
 
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from . import accel
 from . import tune
@@ -88,7 +89,7 @@ class Fill(accel.Operation):
     def _run(self):
         data = self.buffer('data')
 
-        elements = np.product(data.padded_shape)
+        elements = int(np.product(data.padded_shape))
         global_size = accel.roundup(elements, self.template.wgs)
         self.command_queue.enqueue_kernel(
                 self.kernel,

--- a/katsdpsigproc/maskedsum.py
+++ b/katsdpsigproc/maskedsum.py
@@ -1,7 +1,7 @@
 """On-device percentile calculation of 2D arrays"""
-# see scripts/percentiletest.py for an example
+# see scripts/maskedsumtest.py for an example
 
-from __future__ import division
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from . import accel
 from . import tune

--- a/katsdpsigproc/opencl.py
+++ b/katsdpsigproc/opencl.py
@@ -4,6 +4,7 @@ functionality can be added, but should be kept in sync with
 :mod:`katsdpsigproc.cuda`.
 """
 
+from __future__ import division, print_function, absolute_import
 import pyopencl
 import pyopencl.array
 import numpy as np

--- a/katsdpsigproc/percentile.py
+++ b/katsdpsigproc/percentile.py
@@ -1,7 +1,7 @@
 """On-device percentile calculation of 2D arrays"""
 # see scripts/percentiletest.py for an example
 
-from __future__ import division
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from . import accel
 from . import tune

--- a/katsdpsigproc/reduce.py
+++ b/katsdpsigproc/reduce.py
@@ -1,6 +1,7 @@
 #coding: utf-8
 """Reduction algorithms"""
 
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from . import accel
 from . import tune

--- a/katsdpsigproc/resource.py
+++ b/katsdpsigproc/resource.py
@@ -1,5 +1,6 @@
 """Utilities for scheduling device operations with trollius."""
 
+from __future__ import division, print_function, absolute_import
 import trollius
 import logging
 import collections

--- a/katsdpsigproc/rfi/device.py
+++ b/katsdpsigproc/rfi/device.py
@@ -8,12 +8,13 @@ order). In the former case, the `transposed` member is `False`, otherwise it is
 kernel at the appropriate point.
 """
 
-from __future__ import division
+from __future__ import division, print_function, absolute_import
 from .. import accel
 from .. import tune
 from .. import transpose
 from ..accel import DeviceArray
 import numpy as np
+from six.moves import range
 from . import host
 
 class BackgroundHostFromDevice(object):

--- a/katsdpsigproc/rfi/host.py
+++ b/katsdpsigproc/rfi/host.py
@@ -1,8 +1,10 @@
 # coding: utf-8
 """RFI flagging algorithms that run on the CPU."""
 
+from __future__ import division, print_function, absolute_import
 import numpy as np
 import pandas as pd
+from six.moves import range, zip
 
 class BackgroundMedianFilterHost(object):
     """Host backgrounder that applies a median filter to each baseline

--- a/katsdpsigproc/rfi/test/test_background.py
+++ b/katsdpsigproc/rfi/test/test_background.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from .. import host
 from ...test.test_accel import device_test, force_autotune

--- a/katsdpsigproc/rfi/test/test_flagger.py
+++ b/katsdpsigproc/rfi/test/test_flagger.py
@@ -2,6 +2,7 @@
 separate tests - this module just tests that they can be glued together
 properly."""
 
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from .. import host
 from ...test.test_accel import device_test

--- a/katsdpsigproc/rfi/test/test_noise_est.py
+++ b/katsdpsigproc/rfi/test/test_noise_est.py
@@ -1,5 +1,6 @@
 """Tests for RFI noise estimation algorithms"""
 
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from .. import host, device
 from ...test.test_accel import device_test, force_autotune

--- a/katsdpsigproc/rfi/test/test_threshold.py
+++ b/katsdpsigproc/rfi/test/test_threshold.py
@@ -1,5 +1,6 @@
 """Tests for RFI thresholding algorithms"""
 
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from .. import host
 from ...test.test_accel import device_test, force_autotune

--- a/katsdpsigproc/test/test_accel.py
+++ b/katsdpsigproc/test/test_accel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+from __future__ import division, print_function, absolute_import
 import sys
 import numpy as np
 from decorator import decorator
@@ -8,6 +8,7 @@ from nose.tools import assert_equal
 from .test_tune import assert_raises
 from nose.plugins.skip import SkipTest
 import mock
+from six.moves import zip
 from .. import accel, tune
 from ..accel import HostArray, DeviceArray, SVMArray, LinenoLexer
 if accel.have_cuda:
@@ -31,8 +32,9 @@ def device_test(test):
             try:
                 _test_context = accel.create_some_context(False)
                 _test_command_queue = _test_context.create_command_queue()
-                print >>sys.stderr, "Testing on {0} ({1})".format(
-                        _test_context.device.name, _test_context.device.platform_name)
+                print("Testing on {0} ({1})".format(
+                    _test_context.device.name, _test_context.device.platform_name),
+                    file=sys.stderr)
             except RuntimeError:
                 pass  # No devices available
             _test_initialized = True

--- a/katsdpsigproc/test/test_fill.py
+++ b/katsdpsigproc/test/test_fill.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from nose.tools import assert_equal
 from .test_accel import device_test, force_autotune

--- a/katsdpsigproc/test/test_maskedsum.py
+++ b/katsdpsigproc/test/test_maskedsum.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from . import test_accel
 from .test_accel import device_test, force_autotune

--- a/katsdpsigproc/test/test_percentile.py
+++ b/katsdpsigproc/test/test_percentile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from . import test_accel
 from .test_accel import device_test, force_autotune

--- a/katsdpsigproc/test/test_rank.py
+++ b/katsdpsigproc/test/test_rank.py
@@ -1,10 +1,12 @@
 """Tests for rank.mako"""
 
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from .. import accel
 from ..accel import DeviceArray, build
 from .test_accel import device_test
 from nose.tools import assert_equal
+from six.moves import range
 
 @device_test
 def setup(context, queue):

--- a/katsdpsigproc/test/test_reduce.py
+++ b/katsdpsigproc/test/test_reduce.py
@@ -1,9 +1,9 @@
 """Tests for wg_reduce.mako and reduce.py"""
 
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from .test_accel import device_test, force_autotune
 from ..accel import DeviceArray, build
-builtin_reduce = reduce
 from .. import reduce
 
 class Fixture(object):

--- a/katsdpsigproc/test/test_resource.py
+++ b/katsdpsigproc/test/test_resource.py
@@ -1,11 +1,12 @@
 """Tests for :mod:`katsdpsigproc.resource`."""
 
+from __future__ import division, print_function, absolute_import
 from katsdpsigproc import resource
 import functools
 import decorator
 import trollius
 import time
-import Queue
+from six.moves import queue, range
 from trollius import From
 from nose.tools import *
 import mock
@@ -86,7 +87,7 @@ class DummyEvent(object):
 class TestResource(object):
     def setup(self):
         self.loop = trollius.get_event_loop_policy().new_event_loop()
-        self.completed = Queue.Queue()
+        self.completed = queue.Queue()
 
     def teardown(self):
         self.loop.close()
@@ -115,7 +116,7 @@ class TestResource(object):
         try:
             while True:
                 order.append(self.completed.get_nowait())
-        except Queue.Empty:
+        except queue.Empty:
             pass
         assert_equal(order, [a0, e0, a1])
 

--- a/katsdpsigproc/test/test_transpose.py
+++ b/katsdpsigproc/test/test_transpose.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from . import test_accel
 from .test_accel import device_test, force_autotune

--- a/katsdpsigproc/test/test_tune.py
+++ b/katsdpsigproc/test/test_tune.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function, absolute_import
 import sys
 import traceback
 from nose.tools import assert_equal
@@ -55,18 +56,20 @@ def generate_raise(x):
 
 def test_autotune_all_raise():
     exc_value = None
+    exc_info = None
     with assert_raises(CustomError):
         exc_value = None
         try:
             tune.autotune(generate_raise, x=[1, 2, 3])
         except CustomError as e:
             exc_value = e
+            exc_info = sys.exc_info()
             raise
 
     assert_equal('x = 3', str(exc_value))
     # Check that the traceback refers to the original site, not
     # where it was re-raised
-    frames = traceback.extract_tb(sys.exc_info()[2])
+    frames = traceback.extract_tb(exc_info[2])
     assert_equal('generate_raise', frames[-1][2])
 
 class TestAutotuner(object):

--- a/katsdpsigproc/transpose.py
+++ b/katsdpsigproc/transpose.py
@@ -1,6 +1,6 @@
 """On-device transposition of 2D arrays"""
 
-from __future__ import division
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from . import accel
 from . import tune

--- a/scripts/maskedsumabstest.py
+++ b/scripts/maskedsumabstest.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 #for nosetest: nosetests katsdpsigproc.test.test_maskedsumabs
+
+from __future__ import division, print_function, absolute_import
 import time
 import numpy as np
 from katsdpsigproc import accel
@@ -25,5 +27,5 @@ out = msum.buffer('dest').get(queue)
 t0 = time.time()
 expected = np.sum(np.abs(data)*mask.reshape(data.shape[0],1),axis=0).astype(np.float32)
 t1 = time.time()
-print 'gpu:', end_event.time_since(start_event), 'cpu:', t1-t0
+print('gpu:', end_event.time_since(start_event), 'cpu:', t1-t0)
 np.testing.assert_allclose(expected, out.reshape(-1), rtol=1e-6)

--- a/scripts/maskedsumtest.py
+++ b/scripts/maskedsumtest.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 #for nosetest: nosetests katsdpsigproc.test.test_maskedsum
+
+from __future__ import division, print_function, absolute_import
 import time
 import numpy as np
 from katsdpsigproc import accel
@@ -25,5 +27,5 @@ out = msum.buffer('dest').get(queue)
 t0 = time.time()
 expected = np.sum(data*mask.reshape(data.shape[0],1),axis=0).astype(np.complex64)
 t1 = time.time()
-print 'gpu:', end_event.time_since(start_event), 'cpu:', t1-t0
+print('gpu:', end_event.time_since(start_event), 'cpu:', t1-t0)
 np.testing.assert_equal(out.reshape(-1), expected)

--- a/scripts/percentiletest.py
+++ b/scripts/percentiletest.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 #for nosetest: nosetests katsdpsigproc.test.test_percentile
+
+from __future__ import division, print_function, absolute_import
 import time
 import numpy as np
 from katsdpsigproc import accel
@@ -23,5 +25,5 @@ out = perc.buffer('dest').get(queue)
 t0 = time.time()
 expected = np.percentile(data, [0, 100, 25, 75, 50], axis=1, interpolation='lower')
 t1 = time.time()
-print 'gpu:', end_event.time_since(start_event), 'cpu:', t1-t0
+print('gpu:', end_event.time_since(start_event), 'cpu:', t1-t0)
 np.testing.assert_equal(out, expected)

--- a/scripts/rfiflagtest.py
+++ b/scripts/rfiflagtest.py
@@ -2,6 +2,7 @@
 
 """Test script that runs RFI flagging on random or real data."""
 
+from __future__ import division, print_function, absolute_import
 import numpy as np
 import katsdpsigproc.rfi.host
 import katsdpsigproc.rfi.device
@@ -71,7 +72,7 @@ def main():
         try:
             context = accel.create_some_context(True)
         except RuntimeError:
-            print >>sys.stderr, "No devices available. Executing on the CPU."
+            print("No devices available. Executing on the CPU.", file=sys.stderr)
 
     if context is None:
         background = katsdpsigproc.rfi.host.BackgroundMedianFilterHost(args.width)
@@ -81,7 +82,7 @@ def main():
         start = time.time()
         flags = flagger(data)
         end = time.time()
-        print "CPU time (ms):", (end - start) * 1000.0
+        print("CPU time (ms):", (end - start) * 1000.0)
     else:
         command_queue = context.create_command_queue(profile=True)
         background = katsdpsigproc.rfi.device.BackgroundMedianFilterDeviceTemplate(
@@ -110,15 +111,15 @@ def main():
         command_queue.finish()
         end_time = time.time()
         flags = flags_device.get(command_queue)
-        print "Host time (ms):  ", (end_time - start_time) * 1000.0
+        print("Host time (ms):  ", (end_time - start_time) * 1000.0)
         try:
             device_time = end_event.time_since(start_event) * 1000.0
         except:
             # AMD CPU device doesn't seem to support profiling on marker events
             device_time = 'unknown'
-        print "Device time (ms):", device_time
+        print("Device time (ms):", device_time)
 
-    print flags
+    print(flags)
 
 if __name__ == '__main__':
     main()

--- a/scripts/transposetest.py
+++ b/scripts/transposetest.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
+from __future__ import division, print_function, absolute_import
 from katsdpsigproc import accel, transpose
 import numpy as np
+from six.moves import range
 
 dtype = np.complex64
 ctype = 'float2'
@@ -21,4 +23,4 @@ proc()  # Warmup
 for i in range(4):
     queue.start_tuning()
     proc()
-    print queue.stop_tuning()
+    print(queue.stop_tuning())

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url="https://github.com/ska-sa/katsdpsigproc",
     setup_requires=["katversion"],
     install_requires=[
-        "numpy>=1.10", "decorator", "mako", "appdirs", "futures", "pandas", "trollius"
+        "numpy>=1.10", "decorator", "mako", "appdirs", "futures", "pandas", "trollius", "six"
     ],
     extras_require={
         "CUDA": ["pycuda>=2015.1.3"],


### PR DESCRIPTION
This is mostly just a case of applying the changes from
python-modernize. There are a few places where the change is a little
trickier, because Python 3 changes sys.exc_info() so that it only
returns values while the exception handler is active, rather than always
giving access to the last exception.