### PR TITLE
Use CUDA 9.0 sync shuffles when available

### DIFF
--- a/katsdpsigproc/test/test_reduce.py
+++ b/katsdpsigproc/test/test_reduce.py
@@ -19,6 +19,10 @@ class Fixture(object):
             'allow_shuffle': allow_shuffle,
             'broadcast': broadcast,
             'rows': rows})
+        self._description = "Fixture(..., {}, {}, {})".format(size, allow_shuffle, broadcast)
+
+    def __str__(self):
+        return self._description
 
 
 @device_test


### PR DESCRIPTION
This makes the code Volta-compatible, and more importantly, silences the
warnings from the compiler about using the deprecated non-sync shuffle.

Because the contract is that all threads in the workgroup must call the
reduction cooperatively, the mask is just set to full (0xFFFFFFFF).

Fixes SR-1196