### PR TITLE
Avoid installing backport libs on Py3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs
 argparse
 cffi
 decorator
-enum34                     # Needed by numba
+enum34; python_version<'3.4'   # Needed by numba
 funcsigs                   # Needed by numba
 futures
 katversion
@@ -22,6 +22,6 @@ python-dateutil            # Needed by Pandas
 pytools
 pytz                       # Needed by Pandas
 scipy
-singledispatch             # Needed by numba
+singledispatch; python_version<'3.4'  # Needed by numba
 six
 trollius

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "decorator",
         "mako",
         "appdirs",
-        "futures",
+        "futures; python_version<'3.2'",
         "trollius; python_version<'3.4'",
         "six"
     ],


### PR DESCRIPTION
enum34, futures, singledispatch are only needed for Python 2.