### PR TITLE
Prepare for sphinx 2.1

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,8 +32,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon',
-    'sphinxcontrib.asyncio'
+    'sphinx.ext.napoleon'
 ]
 
 # From numpy code: these warnings are harmless
@@ -107,6 +106,10 @@ pygments_style = 'sphinx'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 #keep_warnings = False
 
+rst_prolog = """
+.. |CommandQueue| replace:: :class:`.cuda.CommandQueue` or :class:`.opencl.CommandQueue`
+.. |Context| replace:: :class:`.cuda.Context` or :class:`.opencl.Context`
+"""
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/doc/macros.rst
+++ b/doc/macros.rst
@@ -1,2 +1,0 @@
-.. |CommandQueue| replace:: :class:`cuda.CommandQueue` or :class:`opencl.CommandQueue`
-.. |Context| replace:: :class:`cuda.Context` or :class:`opencl.Context`

--- a/katsdpsigproc/accel.py
+++ b/katsdpsigproc/accel.py
@@ -12,8 +12,6 @@ have_cuda : boolean
     True if PyCUDA could be imported (does not guarantee any CUDA devices)
 have_opencl : boolean
     True if PyOpenCL could be imported (does not guarantee any OpenCL devices)
-
-.. include:: macros.rst
 """
 
 import re

--- a/katsdpsigproc/fill.py
+++ b/katsdpsigproc/fill.py
@@ -1,7 +1,4 @@
-"""Fill device array with a constant value
-
-.. include:: macros.rst
-"""
+"""Fill device array with a constant value"""
 
 import numpy as np
 

--- a/katsdpsigproc/maskedsum.py
+++ b/katsdpsigproc/maskedsum.py
@@ -1,7 +1,4 @@
-"""On-device percentile calculation of 2D arrays
-
-.. include:: macros.rst
-"""
+"""On-device percentile calculation of 2D arrays"""
 # see scripts/maskedsumtest.py for an example
 
 import numpy as np

--- a/katsdpsigproc/percentile.py
+++ b/katsdpsigproc/percentile.py
@@ -1,7 +1,4 @@
-"""On-device percentile calculation of 2D arrays
-
-.. include:: macros.rst
-"""
+"""On-device percentile calculation of 2D arrays"""
 # see scripts/percentiletest.py for an example
 
 import numpy as np

--- a/katsdpsigproc/reduce.py
+++ b/katsdpsigproc/reduce.py
@@ -1,8 +1,5 @@
 # coding: utf-8
-"""Reduction algorithms
-
-.. include:: macros.rst
-"""
+"""Reduction algorithms"""
 
 import numpy as np
 

--- a/katsdpsigproc/rfi/device.py
+++ b/katsdpsigproc/rfi/device.py
@@ -6,8 +6,6 @@ channel-major or baseline-major order (the flags are emitted in the same
 order). In the former case, the `transposed` member is `False`, otherwise it is
 `True`. The flagger classes automatically detect this and apply a transposition
 kernel at the appropriate point.
-
-.. include:: macros.rst
 """
 
 import numpy as np

--- a/katsdpsigproc/transpose.py
+++ b/katsdpsigproc/transpose.py
@@ -1,7 +1,4 @@
-"""On-device transposition of 2D arrays
-
-.. include:: macros.rst
-"""
+"""On-device transposition of 2D arrays"""
 
 from __future__ import division, print_function, absolute_import
 import numpy as np


### PR DESCRIPTION
- Remove sphinxcontrib-asyncio, because sphinx now supports coroutines
  itself.
- Remove macros.rst and use an `rst_prolog` in the config file, since
  the include directive didn't seem to be working quite right any more.