### PR TITLE
Type annotations, round 1

### DIFF
--- a/doc/katsdpsigproc.asyncio.rst
+++ b/doc/katsdpsigproc.asyncio.rst
@@ -1,0 +1,22 @@
+katsdpsigproc.asyncio package
+=============================
+
+Submodules
+----------
+
+katsdpsigproc.asyncio.resource module
+-------------------------------------
+
+.. automodule:: katsdpsigproc.asyncio.resource
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: katsdpsigproc.asyncio
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katsdpsigproc.rfi.rst
+++ b/doc/katsdpsigproc.rfi.rst
@@ -6,7 +6,7 @@ Subpackages
 
 .. toctree::
 
-    katsdpsigproc.rfi.test
+   katsdpsigproc.rfi.test
 
 Submodules
 ----------
@@ -15,31 +15,31 @@ katsdpsigproc.rfi.device module
 -------------------------------
 
 .. automodule:: katsdpsigproc.rfi.device
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 katsdpsigproc.rfi.host module
 -----------------------------
 
 .. automodule:: katsdpsigproc.rfi.host
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 katsdpsigproc.rfi.twodflag module
 ---------------------------------
 
 .. automodule:: katsdpsigproc.rfi.twodflag
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: katsdpsigproc.rfi
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katsdpsigproc.rfi.test.rst
+++ b/doc/katsdpsigproc.rfi.test.rst
@@ -4,51 +4,51 @@ katsdpsigproc.rfi.test package
 Submodules
 ----------
 
-katsdpsigproc.rfi.test.test_background module
----------------------------------------------
+katsdpsigproc.rfi.test.test\_background module
+----------------------------------------------
 
 .. automodule:: katsdpsigproc.rfi.test.test_background
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-katsdpsigproc.rfi.test.test_flagger module
-------------------------------------------
-
-.. automodule:: katsdpsigproc.rfi.test.test_flagger
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-katsdpsigproc.rfi.test.test_noise_est module
---------------------------------------------
-
-.. automodule:: katsdpsigproc.rfi.test.test_noise_est
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-katsdpsigproc.rfi.test.test_threshold module
---------------------------------------------
-
-.. automodule:: katsdpsigproc.rfi.test.test_threshold
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-katsdpsigproc.rfi.test.test_twodflag module
+katsdpsigproc.rfi.test.test\_flagger module
 -------------------------------------------
 
+.. automodule:: katsdpsigproc.rfi.test.test_flagger
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+katsdpsigproc.rfi.test.test\_noise\_est module
+----------------------------------------------
+
+.. automodule:: katsdpsigproc.rfi.test.test_noise_est
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+katsdpsigproc.rfi.test.test\_threshold module
+---------------------------------------------
+
+.. automodule:: katsdpsigproc.rfi.test.test_threshold
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+katsdpsigproc.rfi.test.test\_twodflag module
+--------------------------------------------
+
 .. automodule:: katsdpsigproc.rfi.test.test_twodflag
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: katsdpsigproc.rfi.test
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katsdpsigproc.rst
+++ b/doc/katsdpsigproc.rst
@@ -6,97 +6,106 @@ Subpackages
 
 .. toctree::
 
-    katsdpsigproc.rfi
-    katsdpsigproc.test
+   katsdpsigproc.asyncio
+   katsdpsigproc.rfi
+   katsdpsigproc.test
 
 Submodules
 ----------
+
+katsdpsigproc.abc module
+------------------------
+
+.. automodule:: katsdpsigproc.abc
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 katsdpsigproc.accel module
 --------------------------
 
 .. automodule:: katsdpsigproc.accel
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 katsdpsigproc.cuda module
 -------------------------
 
 .. automodule:: katsdpsigproc.cuda
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 katsdpsigproc.fill module
 -------------------------
 
 .. automodule:: katsdpsigproc.fill
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 katsdpsigproc.maskedsum module
 ------------------------------
 
 .. automodule:: katsdpsigproc.maskedsum
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 katsdpsigproc.opencl module
 ---------------------------
 
 .. automodule:: katsdpsigproc.opencl
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 katsdpsigproc.percentile module
 -------------------------------
 
 .. automodule:: katsdpsigproc.percentile
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 katsdpsigproc.reduce module
 ---------------------------
 
 .. automodule:: katsdpsigproc.reduce
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 katsdpsigproc.resource module
 -----------------------------
 
 .. automodule:: katsdpsigproc.resource
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 katsdpsigproc.transpose module
 ------------------------------
 
 .. automodule:: katsdpsigproc.transpose
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 katsdpsigproc.tune module
 -------------------------
 
 .. automodule:: katsdpsigproc.tune
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: katsdpsigproc
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/katsdpsigproc.test.rst
+++ b/doc/katsdpsigproc.test.rst
@@ -4,83 +4,83 @@ katsdpsigproc.test package
 Submodules
 ----------
 
-katsdpsigproc.test.test_accel module
-------------------------------------
-
-.. automodule:: katsdpsigproc.test.test_accel
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-katsdpsigproc.test.test_fill module
------------------------------------
-
-.. automodule:: katsdpsigproc.test.test_fill
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-katsdpsigproc.test.test_maskedsum module
-----------------------------------------
-
-.. automodule:: katsdpsigproc.test.test_maskedsum
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-katsdpsigproc.test.test_percentile module
------------------------------------------
-
-.. automodule:: katsdpsigproc.test.test_percentile
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-katsdpsigproc.test.test_rank module
------------------------------------
-
-.. automodule:: katsdpsigproc.test.test_rank
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-katsdpsigproc.test.test_reduce module
+katsdpsigproc.test.test\_accel module
 -------------------------------------
 
+.. automodule:: katsdpsigproc.test.test_accel
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+katsdpsigproc.test.test\_fill module
+------------------------------------
+
+.. automodule:: katsdpsigproc.test.test_fill
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+katsdpsigproc.test.test\_maskedsum module
+-----------------------------------------
+
+.. automodule:: katsdpsigproc.test.test_maskedsum
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+katsdpsigproc.test.test\_percentile module
+------------------------------------------
+
+.. automodule:: katsdpsigproc.test.test_percentile
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+katsdpsigproc.test.test\_rank module
+------------------------------------
+
+.. automodule:: katsdpsigproc.test.test_rank
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+katsdpsigproc.test.test\_reduce module
+--------------------------------------
+
 .. automodule:: katsdpsigproc.test.test_reduce
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-katsdpsigproc.test.test_resource module
----------------------------------------
-
-.. automodule:: katsdpsigproc.test.test_resource
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-katsdpsigproc.test.test_transpose module
+katsdpsigproc.test.test\_resource module
 ----------------------------------------
 
-.. automodule:: katsdpsigproc.test.test_transpose
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. automodule:: katsdpsigproc.test.test_resource
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-katsdpsigproc.test.test_tune module
------------------------------------
+katsdpsigproc.test.test\_transpose module
+-----------------------------------------
+
+.. automodule:: katsdpsigproc.test.test_transpose
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+katsdpsigproc.test.test\_tune module
+------------------------------------
 
 .. automodule:: katsdpsigproc.test.test_tune
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: katsdpsigproc.test
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/katsdpsigproc/__init__.py
+++ b/katsdpsigproc/__init__.py
@@ -8,5 +8,5 @@ except ImportError:
     import time as _time
     __version__ = "0.0+unknown.{}".format(_time.strftime('%Y%m%d%H%M'))
 else:
-    __version__ = _katversion.get_version(__path__[0])
+    __version__ = _katversion.get_version(__path__[0])     # type: ignore
 # END VERSION CHECK

--- a/katsdpsigproc/abc.py
+++ b/katsdpsigproc/abc.py
@@ -407,7 +407,7 @@ class AbstractCommandQueue(ABC, Generic[_B, _C, _E, _K]):
         """Block until all enqueued work has completed"""
 
 
-class AbstractTuningCommandQueue(Generic[_B, _C, _E, _K], AbstractCommandQueue[_B, _C, _E, _K]):
+class AbstractTuningCommandQueue(AbstractCommandQueue[_B, _C, _E, _K]):
     """Command queue with extra facilities for autotuning.
 
     It keeps track of kernels that are enqueued since the last call to

--- a/katsdpsigproc/abc.py
+++ b/katsdpsigproc/abc.py
@@ -261,16 +261,6 @@ class AbstractCommandQueue(ABC, Generic[_B, _C, _E, _K]):
         """
 
     @abstractmethod
-    def enqueue_copy_buffer(self, src_buffer: _B, dest_buffer: _B) -> None:
-        """Copy one buffer to another.
-
-        Parameters
-        ----------
-        src_buffer,dest_buffer
-            Source and destination buffers
-        """
-
-    @abstractmethod
     def enqueue_copy_buffer_rect(
             self, src_buffer: _B, dest_buffer: _B, src_origin: int, dest_origin: int,
             shape: Sequence[int], src_strides: Sequence[int], dest_strides: Sequence[int]) -> None:

--- a/katsdpsigproc/abc.py
+++ b/katsdpsigproc/abc.py
@@ -189,7 +189,7 @@ class AbstractContext(ABC, Generic[_B, _RB, _RS, _D, _P, _Q, _TQ]):
 
     @abstractmethod
     def allocate_svm_raw(self, n_bytes: int) -> _RS:
-        """Allow raw storage that can be passed in to :meth:`allocate_svm`."""
+        """Allocate raw storage that can be passed to :meth:`allocate_svm`."""
 
     @abstractmethod
     def allocate_svm(self, shape: Tuple[int, ...], dtype: np.ndarray,

--- a/katsdpsigproc/abc.py
+++ b/katsdpsigproc/abc.py
@@ -19,14 +19,15 @@ class AbstractProgram(ABC):
 
         Parameters
         ----------
-        name : str
+        name
             Name of the kernel function
         """
 
 
 class AbstractKernel(ABC):
-    """Abstraction of a kernel object. The object can be enqueued using
-    :meth:`CommandQueue.enqueue_kernel`.
+    """Abstraction of a kernel object.
+    
+    The object can be enqueued using :meth:`CommandQueue.enqueue_kernel`.
 
     The recommended way to create this object is via
     :meth:`Program.get_kernel`.
@@ -38,9 +39,10 @@ class AbstractKernel(ABC):
 
 
 class AbstractEvent(ABC):
-    """Abstraction of an event. This is more akin to a CUDA event than an
-    OpenCL event, in that it is a marker in a command queue rather than
-    associated with a specific command.
+    """Abstraction of an event.
+    
+    This is more akin to a CUDA event than an OpenCL event, in that it is a
+    marker in a command queue rather than associated with a specific command.
     """
 
     @abstractmethod
@@ -49,20 +51,22 @@ class AbstractEvent(ABC):
 
     @abstractmethod
     def time_since(self: _E, prior_event: _E) -> float:
-        """Return the time in seconds from `prior_event` to self. Unlike the
-        PyCUDA method of the same name, this will wait for the events to
-        complete if they have not already.
+        """Return the time in seconds from `prior_event` to self.
+        
+        Unlike the PyCUDA method of the same name, this will wait for the
+        events to complete if they have not already.
         """
 
     @abstractmethod
     def time_till(self: _E, next_event: _E) -> float:
-        """Return the time in seconds from this event to `next_event`. See
-        :meth:`time_since`.
+        """Return the time in seconds from this event to `next_event`.
+        
+        See  :meth:`time_since`.
         """
 
 
 class AbstractDevice(ABC):
-    """Abstraction of a device"""
+    """Abstraction of a device."""
 
     @abstractmethod
     def make_context(self) -> 'AbstractContext':
@@ -124,7 +128,7 @@ class AbstractDevice(ABC):
 
 
 class AbstractContext(ABC):
-    """Abstraction of an OpenCL/CUDA context"""
+    """Abstraction of an OpenCL/CUDA context."""
 
     @property
     @abstractmethod
@@ -137,9 +141,9 @@ class AbstractContext(ABC):
 
         Parameters
         ----------
-        source : str
+        source
             Source code
-        extra_flags : list, optional
+        extra_flags
             Extra parameters to pass to the compiler
         """
 
@@ -153,11 +157,11 @@ class AbstractContext(ABC):
 
         Parameters
         ----------
-        shape : tuple
+        shape
             Shape for the array
-        dtype : numpy dtype
+        dtype
             Type for the data
-        raw : Low-level buffer, optional
+        raw
             Memory backing the array (automatically allocated if ``None``)
         """
 
@@ -168,9 +172,9 @@ class AbstractContext(ABC):
 
         Parameters
         ----------
-        shape : tuple
+        shape
             Shape for the array
-        dtype : numpy dtype
+        dtype
             Type for the data
         """
 
@@ -188,7 +192,7 @@ class AbstractContext(ABC):
 
         Parameters
         ----------
-        profile : boolean
+        profile
             If true, the command queue will support timing kernels
         """
 
@@ -219,11 +223,11 @@ class AbstractCommandQueue(ABC):
 
         Parameters
         ----------
-        buffer : Low-level device array
+        buffer
             Source
-        data : array-like
+        data
             Target
-        blocking : boolean (optional)
+        blocking
             If true (default) the call blocks until the copy is complete
         """
 
@@ -235,11 +239,11 @@ class AbstractCommandQueue(ABC):
 
         Parameters
         ----------
-        buffer : Low-level device array
+        buffer
             Target
         data : array-like
             Source
-        blocking : boolean (optional)
+        blocking
             If true (default), the call blocks until the source has been fully
             read (it has not necessarily reached the device).
         """
@@ -250,7 +254,7 @@ class AbstractCommandQueue(ABC):
 
         Parameters
         ----------
-        src_buffer,dest_buffer : Low-level device array
+        src_buffer,dest_buffer
             Source and destination buffers
         """
 
@@ -258,23 +262,24 @@ class AbstractCommandQueue(ABC):
     def enqueue_copy_buffer_rect(
             self, src_buffer: Any, dest_buffer: Any, src_origin: int, dest_origin: int,
             shape: Sequence[int], src_strides: Sequence[int], dest_strides: Sequence[int]) -> None:
-        """Copy a subregion of one buffer to another. This is a low-level
-        interface that ignores the shape, strides etc of the buffers, and
-        treats them as byte arrays. It also only supports 3 or fewer
-        dimensions. Use
+        """Copy a subregion of one buffer to another.
+        
+        This is a low-level interface that ignores the shape, strides etc of
+        the buffers, and treats them as byte arrays. It also only supports 3 or
+        fewer dimensions. Use
         :py:meth:`~katsdpsigproc.accel.DeviceArray.copy_region` for a
         high-level interface.
 
         Parameters
         ----------
-        src_buffer,dest_buffer : Low-level device array
+        src_buffer,dest_buffer
             Source and destination buffers
-        src_origin,dest_origin : int
+        src_origin,dest_origin
             Offsets for the start of the copy, in bytes
-        shape : sequence of int
+        shape
             Shape of the region to copy (1-3 elements). The first dimension is
             a byte count.
-        src_strides,dest_strides : sequence of int
+        src_strides,dest_strides
             Strides for the source and destination memory layout, with the same
             length as `shape`. The first element of each must be 1, and each
             element must be a factor of the next element.
@@ -286,28 +291,30 @@ class AbstractCommandQueue(ABC):
             buffer_origin: int, data_origin: int, shape: Sequence[int],
             buffer_strides: Sequence[int], data_strides: Sequence[int],
             blocking: bool = True) -> None:
-        """Copy a region of a buffer to host memory. This is a low-level
-        interface that ignores the shape, strides etc of the buffers, and
-        treats them as byte arrays. It also only supports 3 or fewer dimensions. Use
+        """Copy a region of a buffer to host memory.
+        
+        This is a low-level interface that ignores the shape, strides etc of
+        the buffers, and treats them as byte arrays. It also only supports 3 or
+        fewer dimensions. Use
         :py:meth:`~katsdpsigproc.accel.DeviceArray.set_region` for a high-level
         interface.
 
         Parameters
         ----------
-        buffer : Low-level device array
+        buffer
             Source
         data : array-like
             Target
-        buffer_origin, data_origin : int
+        buffer_origin, data_origin
             Offsets for the start of the copy, in bytes
-        shape : sequence of int
+        shape
             Shape of the region to copy (1-3 elements). The first dimension is
             a byte count.
-        buffer_strides,data_strides : sequence of int
+        buffer_strides,data_strides
             Strides for the destination and source memory layout, with the same
             length as `shape`. The first element of each must be 1, and each
             element must be a factor of the next element.
-        blocking : bool, optional
+        blocking
             If true, block until the transfer is complete.
         """
 
@@ -317,42 +324,39 @@ class AbstractCommandQueue(ABC):
             buffer_origin: int, data_origin: int, shape: Sequence[int],
             buffer_strides: Sequence[int], data_strides: Sequence[int],
             blocking: bool = True) -> None:
-        """Copy a region of host memory to a buffer. This is a low-level
-        interface that ignores the shape, strides etc of the buffers, and
-        treats them as byte arrays. It also only supports 3 or fewer dimensions. Use
+        """Copy a region of host memory to a buffer.
+        
+        This is a low-level interface that ignores the shape, strides etc of
+        the buffers, and treats them as byte arrays. It also only supports 3 or
+        fewer dimensions. Use
         :py:meth:`~katsdpsigproc.accel.DeviceArray.set_region` for a high-level
         interface.
 
         Parameters
         ----------
-        buffer : Low-level array
+        buffer
             Target
         data : array-like
             Source
-        buffer_origin, data_origin : int
+        buffer_origin, data_origin
             Offsets for the start of the copy, in bytes
-        shape : sequence of int
+        shape
             Shape of the region to copy (1-3 elements). The first dimension is
             a byte count.
-        buffer_strides,data_strides : sequence of int
+        buffer_strides,data_strides
             Strides for the destination and source memory layout, with the same
             length as `shape`. The first element of each must be 1, and each
             element must be a factor of the next element.
-        blocking : bool, optional
+        blocking
             If true, block until the transfer is complete.
         """
 
     @abstractmethod
     def enqueue_zero_buffer(self, buffer: Any) -> None:
-        """Fill a buffer with zero bytes.
-
-        Parameters
-        ----------
-        buffer : Low-level device array
-        """
+        """Fill a buffer with zero bytes."""
 
     @abstractmethod
-    def enqueue_kernel(self, kernel: AbstractKernel, args: Sequence[Any],
+    def enqueue_kernel(self, kernel: Any, args: Sequence[Any],
                        global_size: Tuple[int], local_size: Tuple[int]) -> None:
         """Enqueue a kernel to the command queue.
 
@@ -361,15 +365,15 @@ class AbstractCommandQueue(ABC):
 
         Parameters
         ----------
-        kernel : :class:`Kernel`
+        kernel
             Kernel to run
-        args : sequence
+        args
             Arguments to pass to the kernel. Refer to the PyOpenCL/CUDA
             documentation for details. Additionally, this function allows
             a low-level device array to be passed.
-        global_size : tuple
+        global_size
             Number of work-items in each global dimension
-        local_size : tuple
+        local_size
             Number of work-items in each local dimension. Must divide
             exactly into `global_size`.
         """
@@ -379,8 +383,11 @@ class AbstractCommandQueue(ABC):
         """Create an event at this point in the command queue"""
 
     @abstractmethod
-    def enqueue_wait_for_events(self, events: Sequence[AbstractEvent]) -> None:
+    def enqueue_wait_for_events(self, events: Sequence[Any]) -> None:
         """Enqueue a barrier to wait for all events in `events`."""
+        # Note: the sequence elements must be events of the event class
+        # for the specific API. Python's type system isn't powerful enough
+        # to express that, hence Any.
 
     @abstractmethod
     def flush(self) -> None:
@@ -392,10 +399,11 @@ class AbstractCommandQueue(ABC):
 
 
 class AbstractTuningCommandQueue(AbstractCommandQueue):
-    """Command queue with extra facilities for autotuning. It keeps
-    track of kernels that are enqueued since the last call to
-    :meth:`start_tuning`, and reports the total time they consume
-    when :meth:`stop_tuning` is called.
+    """Command queue with extra facilities for autotuning.
+    
+    It keeps track of kernels that are enqueued since the last call to
+    :meth:`start_tuning`, and reports the total time they consume when
+    :meth:`stop_tuning` is called.
     """
 
     @abstractmethod

--- a/katsdpsigproc/abc.py
+++ b/katsdpsigproc/abc.py
@@ -1,0 +1,407 @@
+"""Abstract base classes for :mod:`opencl` and :mod:`cuda`."""
+
+from abc import ABC, abstractmethod
+from typing import List, Tuple, Sequence, Optional, Any, Type, TypeVar
+from types import TracebackType
+
+import numpy as np
+
+
+_E = TypeVar('_E', bound='AbstractEvent')
+
+
+class AbstractProgram(ABC):
+    """Abstraction of a program object"""
+
+    @abstractmethod
+    def get_kernel(self, name: str) -> 'AbstractKernel':
+        """Create a new kernel
+
+        Parameters
+        ----------
+        name : str
+            Name of the kernel function
+        """
+
+
+class AbstractKernel(ABC):
+    """Abstraction of a kernel object. The object can be enqueued using
+    :meth:`CommandQueue.enqueue_kernel`.
+
+    The recommended way to create this object is via
+    :meth:`Program.get_kernel`.
+    """
+
+    @abstractmethod
+    def __init__(self, program: AbstractProgram, name: str) -> None:
+        pass
+
+
+class AbstractEvent(ABC):
+    """Abstraction of an event. This is more akin to a CUDA event than an
+    OpenCL event, in that it is a marker in a command queue rather than
+    associated with a specific command.
+    """
+
+    @abstractmethod
+    def wait(self) -> None:
+        """Block until the event has completed"""
+
+    @abstractmethod
+    def time_since(self: _E, prior_event: _E) -> float:
+        """Return the time in seconds from `prior_event` to self. Unlike the
+        PyCUDA method of the same name, this will wait for the events to
+        complete if they have not already.
+        """
+
+    @abstractmethod
+    def time_till(self: _E, next_event: _E) -> float:
+        """Return the time in seconds from this event to `next_event`. See
+        :meth:`time_since`.
+        """
+
+
+class AbstractDevice(ABC):
+    """Abstraction of a device"""
+
+    @abstractmethod
+    def make_context(self) -> 'AbstractContext':
+        """Create a new context associated with this device"""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return human-readable name for the device"""
+
+    @property
+    @abstractmethod
+    def platform_name(self) -> str:
+        """Return human-readable name for the platform owning the device"""
+
+    @property
+    @abstractmethod
+    def driver_version(self) -> str:
+        """Return human-readable name for the driver version"""
+
+    @property
+    @abstractmethod
+    def is_cuda(self) -> bool:
+        """Whether the device is a CUDA device"""
+
+    @property
+    @abstractmethod
+    def is_gpu(self) -> bool:
+        """Whether device is a GPU"""
+
+    @property
+    @abstractmethod
+    def is_accelerator(self) -> bool:
+        """Whether device is an accelerator (as defined by OpenCL device types)"""
+
+    @property
+    @abstractmethod
+    def is_cpu(self) -> bool:
+        """Whether the device is a CPU"""
+
+    @property
+    @abstractmethod
+    def simd_group_size(self) -> int:
+        """The number of workitems that run in lock-step.
+
+        This must only be used to tune performance parameters; there are no
+        guarantees about memory coherency, forward progress etc.
+        """
+
+    @classmethod
+    @abstractmethod
+    def get_devices(cls) -> Sequence['AbstractDevice']:
+        """Return a list of all devices on all platforms"""
+
+    @classmethod
+    @abstractmethod
+    def get_devices_by_platform(cls) -> Sequence[Sequence['AbstractDevice']]:
+        """Return a list of all devices, with a sub-list per platform."""
+
+
+class AbstractContext(ABC):
+    """Abstraction of an OpenCL/CUDA context"""
+
+    @property
+    @abstractmethod
+    def device(self) -> AbstractDevice:
+        """Return the device associated with the context (or the first device, if multiple)."""
+
+    @abstractmethod
+    def compile(self, source: str, extra_flags: Optional[List[str]] = None) -> AbstractProgram:
+        """Build a program object from source
+
+        Parameters
+        ----------
+        source : str
+            Source code
+        extra_flags : list, optional
+            Extra parameters to pass to the compiler
+        """
+
+    @abstractmethod
+    def allocate_raw(self, n_bytes: int) -> Any:
+        """Create an untyped buffer on the device."""
+
+    @abstractmethod
+    def allocate(self, shape: Tuple[int], dtype: np.dtype, raw: Any = None) -> Any:
+        """Create a typed buffer on the device.
+
+        Parameters
+        ----------
+        shape : tuple
+            Shape for the array
+        dtype : numpy dtype
+            Type for the data
+        raw : Low-level buffer, optional
+            Memory backing the array (automatically allocated if ``None``)
+        """
+
+    @abstractmethod
+    def allocate_pinned(self, shape: Tuple[int], dtype: np.dtype) -> np.ndarray:
+        """Create a buffer in host memory that can be efficiently copied
+        to and from the device.
+
+        Parameters
+        ----------
+        shape : tuple
+            Shape for the array
+        dtype : numpy dtype
+            Type for the data
+        """
+
+    @abstractmethod
+    def allocate_svm_raw(self, n_bytes: int) -> Any:
+        """Allow raw storage that can be passed in to :meth:`allocate_svm`."""
+
+    @abstractmethod
+    def allocate_svm(self, shape: Tuple[int], dtype: np.ndarray, raw: Any = None) -> np.ndarray:
+        """Allocate shared virtual memory."""
+
+    @abstractmethod
+    def create_command_queue(self, profile: bool = False) -> 'AbstractCommandQueue':
+        """Create a new command queue associated with this context
+
+        Parameters
+        ----------
+        profile : boolean
+            If true, the command queue will support timing kernels
+        """
+
+    @abstractmethod
+    def create_tuning_command_queue(self) -> 'AbstractTuningCommandQueue':
+        """Create a new command queue for doing autotuning"""
+
+    @abstractmethod
+    def __enter__(self) -> 'AbstractContext':
+        pass
+
+    @abstractmethod
+    def __exit__(self,
+                 exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> bool:
+        pass
+
+
+class AbstractCommandQueue(ABC):
+    """Abstraction of a command queue."""
+
+    @abstractmethod
+    def enqueue_read_buffer(self, buffer: Any, data: Any, blocking: bool = True) -> None:
+        """Copy data from the device to the host. Only whole-buffer copies are
+        supported, and the shape and type must match. In general, one should use
+        the convenience functions in :class:`accel.DeviceArray`.
+
+        Parameters
+        ----------
+        buffer : Low-level device array
+            Source
+        data : array-like
+            Target
+        blocking : boolean (optional)
+            If true (default) the call blocks until the copy is complete
+        """
+
+    @abstractmethod
+    def enqueue_write_buffer(self, buffer: Any, data: Any, blocking=True) -> None:
+        """Copy data from the host to the device. Only whole-buffer copies are
+        supported, and the shape and type must match. In general, one should
+        use the convenience functions in :class:`accel.DeviceArray`.
+
+        Parameters
+        ----------
+        buffer : Low-level device array
+            Target
+        data : array-like
+            Source
+        blocking : boolean (optional)
+            If true (default), the call blocks until the source has been fully
+            read (it has not necessarily reached the device).
+        """
+
+    @abstractmethod
+    def enqueue_copy_buffer(self, src_buffer: Any, dest_buffer: Any) -> None:
+        """Copy one buffer to another.
+
+        Parameters
+        ----------
+        src_buffer,dest_buffer : Low-level device array
+            Source and destination buffers
+        """
+
+    @abstractmethod
+    def enqueue_copy_buffer_rect(
+            self, src_buffer: Any, dest_buffer: Any, src_origin: int, dest_origin: int,
+            shape: Sequence[int], src_strides: Sequence[int], dest_strides: Sequence[int]) -> None:
+        """Copy a subregion of one buffer to another. This is a low-level
+        interface that ignores the shape, strides etc of the buffers, and
+        treats them as byte arrays. It also only supports 3 or fewer
+        dimensions. Use
+        :py:meth:`~katsdpsigproc.accel.DeviceArray.copy_region` for a
+        high-level interface.
+
+        Parameters
+        ----------
+        src_buffer,dest_buffer : Low-level device array
+            Source and destination buffers
+        src_origin,dest_origin : int
+            Offsets for the start of the copy, in bytes
+        shape : sequence of int
+            Shape of the region to copy (1-3 elements). The first dimension is
+            a byte count.
+        src_strides,dest_strides : sequence of int
+            Strides for the source and destination memory layout, with the same
+            length as `shape`. The first element of each must be 1, and each
+            element must be a factor of the next element.
+        """
+
+    @abstractmethod
+    def enqueue_read_buffer_rect(
+            self, buffer: Any, data: Any,
+            buffer_origin: int, data_origin: int, shape: Sequence[int],
+            buffer_strides: Sequence[int], data_strides: Sequence[int],
+            blocking: bool = True) -> None:
+        """Copy a region of a buffer to host memory. This is a low-level
+        interface that ignores the shape, strides etc of the buffers, and
+        treats them as byte arrays. It also only supports 3 or fewer dimensions. Use
+        :py:meth:`~katsdpsigproc.accel.DeviceArray.set_region` for a high-level
+        interface.
+
+        Parameters
+        ----------
+        buffer : Low-level device array
+            Source
+        data : array-like
+            Target
+        buffer_origin, data_origin : int
+            Offsets for the start of the copy, in bytes
+        shape : sequence of int
+            Shape of the region to copy (1-3 elements). The first dimension is
+            a byte count.
+        buffer_strides,data_strides : sequence of int
+            Strides for the destination and source memory layout, with the same
+            length as `shape`. The first element of each must be 1, and each
+            element must be a factor of the next element.
+        blocking : bool, optional
+            If true, block until the transfer is complete.
+        """
+
+    @abstractmethod
+    def enqueue_write_buffer_rect(
+            self, buffer: Any, data: Any,
+            buffer_origin: int, data_origin: int, shape: Sequence[int],
+            buffer_strides: Sequence[int], data_strides: Sequence[int],
+            blocking: bool = True) -> None:
+        """Copy a region of host memory to a buffer. This is a low-level
+        interface that ignores the shape, strides etc of the buffers, and
+        treats them as byte arrays. It also only supports 3 or fewer dimensions. Use
+        :py:meth:`~katsdpsigproc.accel.DeviceArray.set_region` for a high-level
+        interface.
+
+        Parameters
+        ----------
+        buffer : Low-level array
+            Target
+        data : array-like
+            Source
+        buffer_origin, data_origin : int
+            Offsets for the start of the copy, in bytes
+        shape : sequence of int
+            Shape of the region to copy (1-3 elements). The first dimension is
+            a byte count.
+        buffer_strides,data_strides : sequence of int
+            Strides for the destination and source memory layout, with the same
+            length as `shape`. The first element of each must be 1, and each
+            element must be a factor of the next element.
+        blocking : bool, optional
+            If true, block until the transfer is complete.
+        """
+
+    @abstractmethod
+    def enqueue_zero_buffer(self, buffer: Any) -> None:
+        """Fill a buffer with zero bytes.
+
+        Parameters
+        ----------
+        buffer : Low-level device array
+        """
+
+    @abstractmethod
+    def enqueue_kernel(self, kernel: AbstractKernel, args: Sequence[Any],
+                       global_size: Tuple[int], local_size: Tuple[int]) -> None:
+        """Enqueue a kernel to the command queue.
+
+        .. warning:: It is not thread-safe to call this function in two threads
+            on the same kernel at the same time.
+
+        Parameters
+        ----------
+        kernel : :class:`Kernel`
+            Kernel to run
+        args : sequence
+            Arguments to pass to the kernel. Refer to the PyOpenCL/CUDA
+            documentation for details. Additionally, this function allows
+            a low-level device array to be passed.
+        global_size : tuple
+            Number of work-items in each global dimension
+        local_size : tuple
+            Number of work-items in each local dimension. Must divide
+            exactly into `global_size`.
+        """
+
+    @abstractmethod
+    def enqueue_marker(self) -> AbstractEvent:
+        """Create an event at this point in the command queue"""
+
+    @abstractmethod
+    def enqueue_wait_for_events(self, events: Sequence[AbstractEvent]) -> None:
+        """Enqueue a barrier to wait for all events in `events`."""
+
+    @abstractmethod
+    def flush(self) -> None:
+        """Start enqueued work running, but do not wait for it to complete"""
+
+    @abstractmethod
+    def finish(self) -> None:
+        """Block until all enqueued work has completed"""
+
+
+class AbstractTuningCommandQueue(AbstractCommandQueue):
+    """Command queue with extra facilities for autotuning. It keeps
+    track of kernels that are enqueued since the last call to
+    :meth:`start_tuning`, and reports the total time they consume
+    when :meth:`stop_tuning` is called.
+    """
+
+    @abstractmethod
+    def start_tuning(self) -> None:
+        pass
+
+    @abstractmethod
+    def stop_tuning(self) -> float:
+        pass

--- a/katsdpsigproc/accel.py
+++ b/katsdpsigproc/accel.py
@@ -112,7 +112,8 @@ def _make_lookup(extra_dirs: List[str]) -> TemplateLookup:
 _lookup = _make_lookup([])
 
 
-def build(context: AbstractContext, name: str, render_kws: Mapping[str, Any],
+def build(context: AbstractContext, name: str,
+          render_kws: Optional[Mapping[str, Any]] = None,
           extra_dirs: Optional[List[str]] = None,
           extra_flags: Optional[List[str]] = None,
           source: Optional[str] = None) -> AbstractProgram:

--- a/katsdpsigproc/accel.py
+++ b/katsdpsigproc/accel.py
@@ -20,6 +20,7 @@ import sys
 import io
 import itertools
 from collections import OrderedDict
+from typing import List
 
 import numpy as np
 import mako.lexer
@@ -40,12 +41,12 @@ except ImportError:
     have_opencl = False
 
 
-def divup(x, y):
+def divup(x: int, y: int) -> int:
     """Divide x by y and round the result upwards"""
     return (x + y - 1) // y
 
 
-def roundup(x, y):
+def roundup(x: int, y: int) -> int:
     """Rounds x up to the next multiple of y"""
     return divup(x, y) * y
 
@@ -59,11 +60,11 @@ class LinenoLexer(mako.lexer.Lexer):
         self.preprocessor.insert(0, self._lineno_preproc)
 
     @classmethod
-    def _escape_filename(cls, filename):
+    def _escape_filename(cls, filename: str) -> str:
         """Escapes a string for the C preprocessor"""
         return '"' + re.sub(r'([\\"])', r'\\\1', filename) + '"'
 
-    def _lineno_preproc(self, source):
+    def _lineno_preproc(self, source: str):
         """Insert #line directives between every line in `source` and return
         the result.
         """
@@ -83,7 +84,7 @@ class LinenoLexer(mako.lexer.Lexer):
         return ''.join(out)
 
 
-def _make_lookup(extra_dirs):
+def _make_lookup(extra_dirs: List[str]) -> TemplateLookup:
     dirs = extra_dirs + [pkg_resources.resource_filename(__name__, '')]
     return TemplateLookup(dirs, lexer_cls=LinenoLexer, strict_undefined=True)
 

--- a/katsdpsigproc/cuda.py
+++ b/katsdpsigproc/cuda.py
@@ -211,13 +211,6 @@ class CommandQueue(AbstractCommandQueue[pycuda.gpuarray.GPUArray, Context, Event
             if blocking:
                 self._pycuda_stream.synchronize()
 
-    def enqueue_copy_buffer(self, src_buffer: _AnyBuffer, dest_buffer: _AnyBuffer) -> None:
-        pycuda.driver.memcpy_dtod_async(
-            self._get_device_pointer(dest_buffer),
-            self._get_device_pointer(src_buffer),
-            dest_buffer.nbytes,
-            self._pycuda_stream)
-
     @staticmethod
     def _get_device_pointer(buffer: _AnyBuffer) -> int:
         """Retrieves the device pointer from either a GPUArray or a managed memory allocation."""

--- a/katsdpsigproc/cuda.py
+++ b/katsdpsigproc/cuda.py
@@ -211,6 +211,13 @@ class CommandQueue(AbstractCommandQueue[pycuda.gpuarray.GPUArray, Context, Event
             if blocking:
                 self._pycuda_stream.synchronize()
 
+    def enqueue_copy_buffer(self, src_buffer: _AnyBuffer, dest_buffer: _AnyBuffer) -> None:
+        pycuda.driver.memcpy_dtod_async(
+            self._get_device_pointer(dest_buffer),
+            self._get_device_pointer(src_buffer),
+            dest_buffer.nbytes,
+            self._pycuda_stream)
+
     @staticmethod
     def _get_device_pointer(buffer: _AnyBuffer) -> int:
         """Retrieves the device pointer from either a GPUArray or a managed memory allocation."""

--- a/katsdpsigproc/cuda.py
+++ b/katsdpsigproc/cuda.py
@@ -1,56 +1,58 @@
-"""Abstraction layer over PyCUDA to present an interface that is common
-between CUDA and OpenCL. For documentation on these classes, refer to
-the documentation for :mod:`katsdpsigproc.opencl`, which presents the same
-interfaces.
+"""Abstraction layer over PyCUDA.
+
+It implements the abstract interfaces defined in :mod:`katsdpsigproc.abc`.
 """
 
-from __future__ import division, print_function, absolute_import
+from typing import List, Tuple, Sequence, Optional, Callable, Type, Union, Any
+from types import TracebackType
 
 import numpy as np
-
 import pycuda.driver
 import pycuda.compiler
 import pycuda.gpuarray
 import pycuda.characterize
 
+from .abc import (AbstractProgram, AbstractKernel, AbstractDevice, AbstractContext,
+                  AbstractEvent, AbstractCommandQueue, AbstractTuningCommandQueue)
+
 
 NVCC_FLAGS = pycuda.compiler.DEFAULT_NVCC_FLAGS + ['-lineinfo']
 
 
-class Program(object):
-    def __init__(self, pycuda_module):
+class Program(AbstractProgram):
+    def __init__(self, pycuda_module: pycuda.driver.Module) -> None:
         self._pycuda_program = pycuda_module
 
-    def get_kernel(self, name):
+    def get_kernel(self, name: str) -> 'Kernel':
         return Kernel(self, name)
 
 
-class Kernel(object):
-    def __init__(self, program, name):
+class Kernel(AbstractKernel):
+    def __init__(self, program: Program, name: str) -> None:
         self._pycuda_kernel = program._pycuda_program.get_function(name)
 
 
-class Event(object):
-    def __init__(self, pycuda_event):
+class Event(AbstractEvent):
+    def __init__(self, pycuda_event: pycuda.driver.Event) -> None:
         self._pycuda_event = pycuda_event
 
-    def wait(self):
+    def wait(self) -> None:
         self._pycuda_event.synchronize()
 
-    def time_since(self, prior_event):
+    def time_since(self, prior_event: 'Event') -> float:
         prior_event.wait()
         self.wait()
         return 1e-3 * self._pycuda_event.time_since(prior_event._pycuda_event)
 
-    def time_till(self, next_event):
+    def time_till(self, next_event: 'Event') -> float:
         return next_event.time_since(self)
 
 
-class Device(object):
-    def __init__(self, pycuda_device):
+class Device(AbstractDevice):
+    def __init__(self, pycuda_device: pycuda.driver.Device) -> None:
         self._pycuda_device = pycuda_device
 
-    def make_context(self):
+    def make_context(self) -> 'Context':
         pycuda_context = self._pycuda_device.make_context()
         # The above also makes the context current, which we do not
         # want (it leads to errors on termination).
@@ -58,93 +60,98 @@ class Device(object):
         return Context(pycuda_context)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._pycuda_device.name()
 
     @property
-    def platform_name(self):
+    def platform_name(self) -> str:
         return 'CUDA'
 
     @property
-    def driver_version(self):
+    def driver_version(self) -> str:
         return 'CUDA:{0[0]}{0[1]}{0[2]} Driver:{1}'.format(
             pycuda.driver.get_version(), pycuda.driver.get_driver_version())
 
     @property
-    def is_cuda(self):
+    def is_cuda(self) -> bool:
         return True
 
     @property
-    def is_gpu(self):
+    def is_gpu(self) -> bool:
         return True
 
     @property
-    def is_accelerator(self):
+    def is_accelerator(self) -> bool:
         return False
 
     @property
-    def is_cpu(self):
+    def is_cpu(self) -> bool:
         return False
 
     @property
-    def simd_group_size(self):
+    def simd_group_size(self) -> int:
         return self._pycuda_device.warp_size
 
     @classmethod
-    def get_devices(cls):
+    def get_devices(cls) -> List['Device']:
         num_devices = pycuda.driver.Device.count()
         return [Device(pycuda.driver.Device(i)) for i in range(num_devices)]
 
+    @classmethod
+    def get_devices_by_platform(cls) -> List[List['Device']]:
+        return [cls.get_devices()]
 
-class _RawManaged(object):
+
+class _RawManaged:
     """Wraps a PyCUDA managed allocation into an opaque object.
 
     The managed memory API is different to the device memory API, in that one
     cannot allocate a raw pointer. Thus, "raw" allocations are wrapped in this
     class so that they are not accidentally used as numpy arrays.
     """
-    def __init__(self, wrapped):
+    def __init__(self, wrapped: np.ndarray) -> None:
         self._wrapped = wrapped
 
-    def get_array(self, shape, dtype):
-        """Returns a view of (a prefix of) the memory, with the given shape and
-        type."""
+    def get_array(self, shape: Tuple[int], dtype: np.dtype) -> np.ndarray:
+        """Returns a view of (a prefix of) the memory, with the given shape and type."""
         size = int(np.product(shape)) * np.dtype(dtype).itemsize
         return self._wrapped[:size].view(dtype).reshape(shape)
 
 
-class Context(object):
-    def __init__(self, pycuda_context):
+class Context(AbstractContext):
+    def __init__(self, pycuda_context: pycuda.driver.Context) -> None:
         self._pycuda_context = pycuda_context
 
     @property
-    def device(self):
+    def device(self) -> Device:
         with self:
             return Device(pycuda.driver.Context.get_device())
 
-    def compile(self, source, extra_flags=None):
+    def compile(self, source: str, extra_flags: Optional[List[str]] = None) -> Program:
         with self:
             module = pycuda.compiler.SourceModule(source, options=NVCC_FLAGS + extra_flags)
             return Program(module)
 
-    def allocate_raw(self, n_bytes):
+    def allocate_raw(self, n_bytes: int) -> pycuda.driver.DeviceAllocation:
         with self:
             return pycuda.driver.mem_alloc(n_bytes)
 
-    def allocate(self, shape, dtype, raw=None):
+    def allocate(self, shape: Tuple[int], dtype: np.ndarray,
+                 raw: Optional[pycuda.driver.DeviceAllocation] = None):
         with self:
             return pycuda.gpuarray.GPUArray(shape, dtype, gpudata=raw)
 
-    def allocate_pinned(self, shape, dtype):
+    def allocate_pinned(self, shape: Tuple[int], dtype: np.dtype) -> np.ndarray:
         with self:
             return pycuda.driver.pagelocked_empty(shape, dtype)
 
-    def allocate_svm_raw(self, n_bytes):
+    def allocate_svm_raw(self, n_bytes: int) -> _RawManaged:
         with self:
             return _RawManaged(pycuda.driver.managed_empty(
                 (n_bytes,), np.uint8, mem_flags=pycuda.driver.mem_attach_flags.GLOBAL))
 
-    def allocate_svm(self, shape, dtype, raw=None):
+    def allocate_svm(self, shape: Tuple[int], dtype: np.dtype,
+                     raw: Optional[_RawManaged] = None) -> np.ndarray:
         with self:
             if raw is None:
                 return pycuda.driver.managed_empty(
@@ -152,30 +159,36 @@ class Context(object):
             else:
                 return raw.get_array(shape, dtype)
 
-    def create_command_queue(self, profile=False):
+    def create_command_queue(self, profile: bool = False) -> 'CommandQueue':
         return CommandQueue(self, profile=profile)
 
-    def create_tuning_command_queue(self):
+    def create_tuning_command_queue(self) -> TuningCommandQueue:
         return TuningCommandQueue(self)
 
-    def __enter__(self):
+    def __enter__(self) -> 'Context':
         self._pycuda_context.push()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self,
+                 exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> bool:
         self._pycuda_context.pop()
         return False
 
 
-class CommandQueue(object):
-    def __init__(self, context, pycuda_stream=None, profile=False):
+class CommandQueue(AbstractCommandQueue):
+    def __init__(self, context: Context, pycuda_stream: Optional[pycuda.Driver.Stream] = None,
+                 profile: bool = False) -> None:
         self.context = context
         if pycuda_stream is None:
             with context:
-                pycuda_stream = pycuda.driver.Stream()
-        self._pycuda_stream = pycuda_stream
+                self._pycuda_stream = pycuda.driver.Stream()
+        else:
+            self._pycuda_stream = pycuda_stream
 
-    def enqueue_read_buffer(self, buffer, data, blocking=True):
+    def enqueue_read_buffer(self, buffer: pycuda.gpuarray.GPUArray, data: Any,
+                            blocking: bool = True) -> None:
         with self.context:
             # CUDA doesn't support synchronous transfers sequenced in a stream
             # (PyCUDA simply doesn't pass on the stream argument), so use an
@@ -184,7 +197,8 @@ class CommandQueue(object):
             if blocking:
                 self._pycuda_stream.synchronize()
 
-    def enqueue_write_buffer(self, buffer, data, blocking=True):
+    def enqueue_write_buffer(self, buffer: pycuda.gpuarray.GPUArray, data: Any,
+                             blocking: bool = True) -> None:
         with self.context:
             # See comment in enqueue_read_buffer
             buffer.set_async(data, self._pycuda_stream)
@@ -192,18 +206,18 @@ class CommandQueue(object):
                 self._pycuda_stream.synchronize()
 
     @staticmethod
-    def _get_device_pointer(buffer):
-        """Retrieves the device pointer from either a GPUArray or a managed
-        memory allocation.
-        """
+    def _get_device_pointer(buffer: Union[pycuda.gpuarray.GPUArray, np.ndarray]) -> int:
+        """Retrieves the device pointer from either a GPUArray or a managed memory allocation."""
         if isinstance(buffer, pycuda.gpuarray.GPUArray):
             return int(buffer.gpudata)
         else:
             return buffer.base.get_device_pointer()
 
     def enqueue_copy_buffer_rect(
-            self, src_buffer, dest_buffer, src_origin, dest_origin,
-            shape, src_strides, dest_strides):
+            self, src_buffer: Union[pycuda.gpuarray.GPUArray, np.ndarray],
+            dest_buffer: pycuda.gpuarray.GPUArray,
+            src_origin: int, dest_origin: int,
+            shape: Sequence[int], src_strides: Sequence[int], dest_strides: Sequence[int]) -> None:
         with self.context:
             assert src_strides[0] == 1
             assert dest_strides[0] == 1
@@ -234,15 +248,17 @@ class CommandQueue(object):
                 copy(self._pycuda_stream)
 
     @classmethod
-    def _byte_buffer(cls, data):
+    def _byte_buffer(cls, data: np.ndarray) -> np.ndarray:
         """Reinterpret a contiguous array as an array of bytes"""
         view = data.view()
         view.shape = data.size   # Reshape while disallowing copy
         return view.view(np.uint8)
 
     def enqueue_read_buffer_rect(
-            self, buffer, data, buffer_origin, data_origin, shape,
-            buffer_strides, data_strides, blocking=True):
+            self, buffer: Union[pycuda.gpuarray.GPUArray, np.ndarray], data: Any,
+            buffer_origin: int, data_origin: int, shape: Sequence[int],
+            buffer_strides: Sequence[int], data_strides: Sequence[int],
+            blocking: bool = True) -> None:
         with self.context:
             assert buffer_strides[0] == 1
             assert data_strides[0] == 1
@@ -275,8 +291,10 @@ class CommandQueue(object):
                 self._pycuda_stream.synchronize()
 
     def enqueue_write_buffer_rect(
-            self, buffer, data, buffer_origin, data_origin, shape,
-            buffer_strides, data_strides, blocking=True):
+            self, buffer: Union[pycuda.gpuarray.GPUArray, np.ndarray], data: Any,
+            buffer_origin: int, data_origin: int, shape: Sequence[int],
+            buffer_strides: Sequence[int], data_strides: Sequence[int],
+            blocking: bool = True) -> None:
         with self.context:
             assert buffer_strides[0] == 1
             assert data_strides[0] == 1
@@ -308,7 +326,7 @@ class CommandQueue(object):
             if blocking:
                 self._pycuda_stream.synchronize()
 
-    def enqueue_zero_buffer(self, buffer):
+    def enqueue_zero_buffer(self, buffer: Union[pycuda.gpuarray.GPUArray, np.ndarray]) -> None:
         with self.context:
             if isinstance(buffer, pycuda.gpuarray.GPUArray):
                 pycuda.driver.memset_d8(buffer.gpudata, 0, buffer.mem_size * buffer.dtype.itemsize)
@@ -317,7 +335,8 @@ class CommandQueue(object):
                 pycuda.driver.memset_d8(buffer.base.get_device_pointer(), 0,
                                         buffer.size * buffer.dtype.itemsize)
 
-    def enqueue_kernel(self, kernel, args, global_size, local_size):
+    def enqueue_kernel(self, kernel: Kernel, args: Sequence[Any],
+                       global_size: Tuple[int], local_size: Tuple[int]) -> None:
         assert len(global_size) == len(local_size)
         block = [1, 1, 1]
         grid = [1, 1, 1]
@@ -329,38 +348,38 @@ class CommandQueue(object):
             kernel._pycuda_kernel(*args, block=tuple(block), grid=tuple(grid),
                                   stream=self._pycuda_stream)
 
-    def enqueue_marker(self):
+    def enqueue_marker(self) -> 'Event':
         with self.context:
             event = pycuda.driver.Event()
             event.record(self._pycuda_stream)
         return Event(event)
 
-    def enqueue_wait_for_events(self, events):
+    def enqueue_wait_for_events(self, events: Sequence[Event]) -> None:
         with self.context:
             for event in events:
                 self._pycuda_stream.wait_for_event(event._pycuda_event)
 
-    def flush(self):
+    def flush(self) -> None:
         with self.context:
             # This anecdotally flushes, but isn't tested
             self._pycuda_stream.is_done()
 
-    def finish(self):
+    def finish(self) -> None:
         with self.context:
             self._pycuda_stream.synchronize()
 
 
-class TuningCommandQueue(CommandQueue):
+class TuningCommandQueue(CommandQueue, AbstractTuningCommandQueue):
     def __init__(self, *args, **kwargs):
         super(TuningCommandQueue, self).__init__(*args, **kwargs)
         self.is_tuning = False
         self._start_event = None
 
-    def start_tuning(self):
+    def start_tuning(self) -> None:
         self.is_tuning = True
         self._start_event = self.enqueue_marker()
 
-    def stop_tuning(self):
+    def stop_tuning(self) -> float:
         elapsed = 0.0
         if self._start_event is not None:
             end_event = self.enqueue_marker()

--- a/katsdpsigproc/opencl.py
+++ b/katsdpsigproc/opencl.py
@@ -3,7 +3,7 @@
 It implements the abstract interfaces defined by :mod:`katsdpsigproc.abc`.
 """
 
-from typing import List, Tuple, Sequence, Optional, Callable, Type, TypeVar, Any
+from typing import List, Tuple, Sequence, Optional, Callable, Type, TypeVar, Union, Any
 from types import TracebackType
 
 import pyopencl
@@ -16,11 +16,13 @@ from .abc import (AbstractProgram, AbstractKernel, AbstractDevice, AbstractConte
 
 _T = TypeVar('_T')
 _D = TypeVar('_D', bound='Device')
+_AnyBuffer = Union['_DummyArray', pyopencl.array.Array]
 
 
 class _DummyArray:
     """Trivial dummy for :class:`pyopencl.array.Array`, that just has a `data` attribute."""
-    def __init__(self, data: Any) -> None:
+
+    def __init__(self, data: pyopencl.Buffer) -> None:
         self.data = data
 
 
@@ -344,13 +346,13 @@ class CommandQueue(AbstractCommandQueue[pyopencl.array.Array, Context, Event, Ke
             buffer.set(ary=data, queue=self._pyopencl_command_queue, async_=not blocking)
 
     def enqueue_copy_buffer(
-            self, src_buffer: pyopencl.array.Array, dest_buffer: pyopencl.array.Array) -> None:
+            self, src_buffer: _AnyBuffer, dest_buffer: _AnyBuffer) -> None:
         pyopencl.enqueue_copy(
             self._pyopencl_command_queue,
             src=src_buffer.data, dest=dest_buffer.data)
 
     def enqueue_copy_buffer_rect(
-            self, src_buffer: pyopencl.array.Array, dest_buffer: pyopencl.array.Array,
+            self, src_buffer: _AnyBuffer, dest_buffer: _AnyBuffer,
             src_origin: int, dest_origin: int,
             shape: Sequence[int], src_strides: Sequence[int], dest_strides: Sequence[int]) -> None:
         assert src_strides[0] == 1

--- a/katsdpsigproc/opencl.py
+++ b/katsdpsigproc/opencl.py
@@ -1,7 +1,6 @@
-"""Abstraction layer over PyOpenCL to present an interface that is common
-between CUDA and OpenCL. This is only the subset that is needed so far. New
-functionality can be added, but should be kept in sync with
-:mod:`katsdpsigproc.cuda`.
+"""Abstraction layer over PyOpenCL.
+
+It implements the abstract interfaces defined by :mod:`katsdpsigproc.abc`.
 """
 
 from typing import List, Tuple, Sequence, Optional, Callable, Type, Any

--- a/katsdpsigproc/test/test_accel.py
+++ b/katsdpsigproc/test/test_accel.py
@@ -761,7 +761,8 @@ class TestVisualizeOperation(object):
     A real test requires a human to sanity-check the visual output.
     """
     class Inner(accel.Operation):
-        pass
+        def _run(self) -> None:
+            pass
 
     def setup(self):
         self.tmpdir = tempfile.mkdtemp()
@@ -771,7 +772,7 @@ class TestVisualizeOperation(object):
 
     @device_test
     def test(self, context, queue):
-        inner = accel.Operation(queue)
+        inner = TestVisualizeOperation.Inner(queue)
         inner.slots['foo'] = accel.IOSlot((3, 4), np.float32)
         inner.slots['bar'] = accel.IOSlot((4, 3), np.float32)
 

--- a/katsdpsigproc/test/test_accel.py
+++ b/katsdpsigproc/test/test_accel.py
@@ -101,8 +101,8 @@ def force_autotune(test, *args, **kw):
 
 
 # Prevent nose from treating it as a test
-device_test.__test__ = False
-cuda_test.__test__ = False
+device_test.__test__ = False         # type: ignore
+cuda_test.__test__ = False           # type: ignore
 
 
 class TestLinenoLexer(object):


### PR DESCRIPTION
Add type annotations to the core classes. The biggest change is that the common interface provided by `cuda.py` and `opencl.py` is made explicit through abstract base classes e.g. `AbstractContext`. Unfortunately the PEP 484 type system doesn't (as far as I know) have an easy way to specify a multi-class abstract interface, so I've had to do some nasty things with generics so that the concrete classes can only work with the other concrete classes from the same interface.

I've also cleaned up some of the docstrings to be PEP 257, in particular having the summary on one line. A side benefit of the changes is that the docstrings are now in the abstract base classes, and Sphinx propagates them to the derived classes.