### PR TITLE
Type annotations round 2

### DIFF
--- a/katsdpsigproc/accel.py
+++ b/katsdpsigproc/accel.py
@@ -1427,7 +1427,7 @@ class Operation(ABC):
             if not slot.is_bound():
                 slot.allocate(self.allocator)
 
-    def buffer(self, name: str) -> Optional[DeviceArray]:
+    def buffer(self, name: str) -> DeviceArray:
         """Retrieve the buffer bound to a slot.
 
         It will consult both :attr:`slots` and :attr:`hidden_slots`.
@@ -1448,6 +1448,8 @@ class Operation(ABC):
             If no slot with this name exists
         TypeError
             If the slot exists but it is an alias slot
+        ValueError
+            If the slot exists but does not yet have a buffer bound
         """
         try:
             slot = self.slots[name]
@@ -1457,6 +1459,8 @@ class Operation(ABC):
             except KeyError:
                 raise KeyError('no slot named ' + name)
         if isinstance(slot, IOSlot):
+            if slot.buffer is None:
+                raise ValueError('slot ' + name + ' has no buffer bound')
             return slot.buffer
         else:
             raise TypeError('slot ' + name + ' is an alias slot')

--- a/katsdpsigproc/accel.py
+++ b/katsdpsigproc/accel.py
@@ -1440,13 +1440,14 @@ class Operation(ABC):
         Returns
         -------
         :class:`DeviceArray`
-            Buffer bound to slot `name`, or `None` if the slot exists but is unbound
-            or is an alias slot.
+            Buffer bound to slot `name`.
 
         Raises
         ------
         KeyError
             If no slot with this name exists
+        TypeError
+            If the slot exists but it is an alias slot
         """
         try:
             slot = self.slots[name]
@@ -1458,7 +1459,7 @@ class Operation(ABC):
         if isinstance(slot, IOSlot):
             return slot.buffer
         else:
-            return None
+            raise TypeError('slot ' + name + ' is an alias slot')
 
     def required_bytes(self) -> int:
         """Number of bytes of device storage required"""

--- a/katsdpsigproc/fill.py
+++ b/katsdpsigproc/fill.py
@@ -85,7 +85,8 @@ class Fill(accel.Operation):
     """
 
     def __init__(self, template: FillTemplate, command_queue: AbstractCommandQueue,
-                 shape: Tuple[int, ...], allocator: Optional[accel.AbstractAllocator] = None) -> None:
+                 shape: Tuple[int, ...],
+                 allocator: Optional[accel.AbstractAllocator] = None) -> None:
         super(Fill, self).__init__(command_queue, allocator)
         self.template = template
         self.kernel = template.program.get_kernel("fill")

--- a/katsdpsigproc/opencl.py
+++ b/katsdpsigproc/opencl.py
@@ -33,7 +33,7 @@ class _PinnedAMD(np.ndarray):
     are done by unmapping the buffer, enqueuing the copy, and remapping
     the buffer. This is based on AMD's optimization guide.
     """
-    _mapping: pyopencl.MemoryMap
+    _mapping = None     # type: pyopencl.MemoryMap
 
     def __new__(cls, context: 'Context', queue: 'CommandQueue',
                 shape: Tuple[int, ...], dtype: np.dtype) -> '_PinnedAMD':

--- a/katsdpsigproc/reduce.py
+++ b/katsdpsigproc/reduce.py
@@ -1,39 +1,47 @@
 # coding: utf-8
 """Reduction algorithms"""
 
+from typing import Tuple, Mapping, Callable, Optional, Any, cast
+from typing_extensions import TypedDict
+
 import numpy as np
 
 from . import accel
 from . import tune
+from .abc import AbstractContext, AbstractCommandQueue
 
 
-class HReduceTemplate(object):
+_TuningDict = TypedDict('_TuningDict', {'wgsx': int, 'wgsy': int})
+
+
+class HReduceTemplate:
     """Performs reduction along rows in a 2D array. Only commutative reduction
     operators are supported.
 
     Parameters
     ----------
-    context : |Context|
+    context
         Context for which kernels will be compiled
-    dtype : numpy dtype
+    dtype
         Type of data elements
-    ctype : str
+    ctype
         Type (in C/CUDA, not numpy) of data elements
-    op : str
+    op
         C expression to combine two variables, *a* and *b*
-    identity : str
+    identity
         C expression for an identity value for *op*
-    extra_code : str, optional
+    extra_code
         Arbitrary C code to paste in (for use by *op* or *identity*)
-
-    tuning : dict, optional
+    tuning
         Kernel tuning parameters; if omitted, will autotune. The possible
         parameters are
 
         - wgsx: number of workitems per workgroup per row
         - wgsy: number of rows to handle per workgroup
     """
-    def __init__(self, context, dtype, ctype, op, identity, extra_code='', tuning=None):
+    def __init__(self, context: AbstractContext, dtype: np.dtype, ctype: str,
+                 op: str, identity: str, extra_code: str = '',
+                 tuning: Optional[_TuningDict] = None) -> None:
         self.context = context
         self.dtype = dtype
         self.ctype = ctype
@@ -50,7 +58,8 @@ class HReduceTemplate(object):
 
     @classmethod
     @tune.autotuner(test={'wgsx': 64, 'wgsy': 4})
-    def autotune(cls, context, dtype, ctype, op, identity, extra_code):
+    def autotune(cls, context: AbstractContext, dtype: np.dtype, ctype: str,
+                 op: str, identity: str, extra_code: str) -> _TuningDict:
         queue = context.create_tuning_command_queue()
         shape = (2048, 1024)
         src = accel.DeviceArray(context, shape, dtype=dtype)
@@ -66,12 +75,14 @@ class HReduceTemplate(object):
             fn.ensure_all_bound()
             return tune.make_measure(queue, fn)
 
-        return tune.autotune(generate,
-                             wgsx=[32, 64, 128],
-                             wgsy=[1, 2, 4, 8, 16])
+        return cast(_TuningDict, tune.autotune(generate,
+                                               wgsx=[32, 64, 128],
+                                               wgsy=[1, 2, 4, 8, 16]))
 
-    def instantiate(self, *args, **kwargs):
-        return HReduce(self, *args, **kwargs)
+    def instantiate(self, command_queue: AbstractCommandQueue, shape: Tuple[int, int],
+                    column_range: Optional[Tuple[int, int]] = None,
+                    allocator: Optional[accel.AbstractAllocator] = None) -> 'HReduce':
+        return HReduce(self, command_queue, shape, column_range, allocator)
 
 
 class HReduce(accel.Operation):
@@ -89,18 +100,20 @@ class HReduce(accel.Operation):
 
     Parameters
     ----------
-    template : :class:`FillTemplate`
+    template
         Operation template
-    command_queue : |CommandQueue|
+    command_queue
         Command queue for the operation
-    shape : 2-tuple of int
+    shape
         Shape for the source slot
-    column_range : 2-tuple of int, optional
+    column_range
         Half-open range of columns to reduce (defaults to the entire array)
-    allocator : :class:`DeviceAllocator` or :class:`SVMAllocator`, optional
+    allocator
         Allocator used to allocate unbound slots
     """
-    def __init__(self, template, command_queue, shape, column_range=None, allocator=None):
+    def __init__(self, template: HReduceTemplate, command_queue: AbstractCommandQueue,
+                 shape: Tuple[int, int], column_range: Optional[Tuple[int, int]] = None,
+                 allocator: Optional[accel.AbstractAllocator] = None) -> None:
         if len(shape) != 2:
             raise ValueError('shape must be 2-dimensional')
         if column_range is None:
@@ -121,7 +134,7 @@ class HReduce(accel.Operation):
             (accel.Dimension(shape[0], self.template.wgsy),),
             self.template.dtype)
 
-    def _run(self):
+    def _run(self) -> None:
         src = self.buffer('src')
         dest = self.buffer('dest')
         rows_padded = accel.roundup(src.shape[0], self.template.wgsy)
@@ -136,11 +149,11 @@ class HReduce(accel.Operation):
             global_size=(self.template.wgsx, rows_padded),
             local_size=(self.template.wgsx, self.template.wgsy))
 
-    def parameters(self):
+    def parameters(self) -> Mapping[str, Any]:
         return {
             'dtype': self.template.dtype,
             'ctype': self.template.ctype,
-            'shape': self.slots['src'].shape,
+            'shape': self.slots['src'].shape,    # type: ignore
             'column_range': self.column_range,
             'op': self.template.op,
             'identity': self.template.identity,

--- a/katsdpsigproc/reduce.py
+++ b/katsdpsigproc/reduce.py
@@ -65,11 +65,12 @@ class HReduceTemplate:
         src = accel.DeviceArray(context, shape, dtype=dtype)
         dest = accel.DeviceArray(context, (shape[0],), dtype=dtype)
 
-        def generate(**kwargs):
-            wgs = kwargs['wgsx'] * kwargs['wgsy']
+        def generate(wgsx: int, wgsy: int) -> Callable[[int], float]:
+            wgs = wgsx * wgsy
             if wgs < 32 or wgs > 1024:
-                raise RuntimeError('Skipping work group size {wgsx}x{wgsy}'.format(**kwargs))
-            template = cls(context, dtype, ctype, op, identity, extra_code, kwargs)
+                raise RuntimeError('Skipping work group size {}x{}'.format(wgsx, wgsy))
+            template = cls(context, dtype, ctype, op, identity, extra_code,
+                           {'wgsx': wgsx, 'wgsy': wgsy})
             fn = template.instantiate(queue, shape)
             fn.bind(src=src, dest=dest)
             fn.ensure_all_bound()

--- a/katsdpsigproc/resource.py
+++ b/katsdpsigproc/resource.py
@@ -155,7 +155,7 @@ class Resource(Generic[_T]):
 
     def acquire(self) -> ResourceAllocation[_T]:
         """Indicate intent to acquire the resource.
-        
+
         This does not actually acquire the resource, but instead returns a
         handle that can be used to acquire and release it later. Acquisitions
         always occur in the order in which calls to :meth:`acquire` are made.
@@ -175,7 +175,7 @@ class JobQueue:
 
     def add(self, job: Awaitable) -> None:
         """Append a job to the list.
-        
+
         If `job` is a coroutine, it is automatically wrapped in a task."""
         self._jobs.append(asyncio.ensure_future(job))
 

--- a/katsdpsigproc/test/test_accel.py
+++ b/katsdpsigproc/test/test_accel.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 from textwrap import dedent
 from unittest import mock
+from typing import Tuple, Optional, Callable, Awaitable, Type, TypeVar, Any
 
 import numpy as np
 from decorator import decorator
@@ -14,20 +15,23 @@ from mako.template import Template
 from nose.tools import assert_equal, assert_raises
 from nose.plugins.skip import SkipTest
 
-from .. import accel, tune
+from .. import accel, tune, opencl
 from ..accel import HostArray, DeviceArray, SVMArray, LinenoLexer
+from ..abc import AbstractContext, AbstractCommandQueue
 if accel.have_cuda:
     import pycuda
 if accel.have_opencl:
     import pyopencl
 
 
-_test_context = None
-_test_command_queue = None
+_T = TypeVar('_T')
+_F = TypeVar('_F', bound=Callable)
+_test_context = None           # type: Optional[AbstractContext]
+_test_command_queue = None     # type: Optional[AbstractCommandQueue]
 _test_initialized = False
 
 
-def _prepare_device_test():
+def _prepare_device_test() -> Tuple[AbstractContext, AbstractCommandQueue]:
     global _test_initialized, _test_context, _test_command_queue
     if not _test_initialized:
         try:
@@ -42,45 +46,47 @@ def _prepare_device_test():
 
     if not _test_context:
         raise SkipTest('CUDA/OpenCL not found')
+    assert _test_command_queue is not None
+    return _test_context, _test_command_queue
 
 
-def _device_test_sync(test):
+def _device_test_sync(test: Callable[..., _T]) -> Callable[..., _T]:
     @functools.wraps(test)
-    def wrapper(*args, **kwargs):
-        _prepare_device_test()
+    def wrapper(*args, **kwargs) -> _T:
+        context, command_queue = _prepare_device_test()
         with mock.patch('katsdpsigproc.tune.autotuner_impl', new=tune.stub_autotuner):
-            args += (_test_context, _test_command_queue)
+            args += (context, command_queue)
             # Make the context current (for CUDA contexts). Ideally the test
             # should not depend on this, but PyCUDA leaks memory if objects
             # are deleted without the context current.
-            with _test_context:
+            with context:
                 return test(*args, **kwargs)
     return wrapper
 
 
-def _device_test_async(test):
+def _device_test_async(test: Callable[..., Awaitable[_T]]) -> Callable[..., Awaitable[_T]]:
     @functools.wraps(test)
-    async def wrapper(*args, **kwargs):
-        _prepare_device_test()
+    async def wrapper(*args, **kwargs) -> _T:
+        context, command_queue = _prepare_device_test()
         with mock.patch('katsdpsigproc.tune.autotuner_impl', new=tune.stub_autotuner):
-            args += (_test_context, _test_command_queue)
-            with _test_context:
+            args += (context, command_queue)
+            with context:
                 return await test(*args, **kwargs)
     return wrapper
 
 
-def device_test(test):
+def device_test(test: Callable[..., _T]) -> Callable[..., _T]:
     """Decorator that causes a test to be skipped if a compute device is not
     available, and which disables autotuning. If autotuning is desired, use
     :func:`force_autotune` inside (hence, afterwards on the decorator list)
     this one."""
     if inspect.iscoroutinefunction(test):
-        return _device_test_async(test)   # noqa: F821
+        return _device_test_async(test)    # type: ignore
     else:
         return _device_test_sync(test)
 
 
-def cuda_test(test):
+def cuda_test(test: _F) -> _F:
     """Decorator that causes a test to be skipped if the device is not a CUDA
     device. Put this *after* :meth:`device_test`."""
     @functools.wraps(test)
@@ -89,11 +95,11 @@ def cuda_test(test):
         if not _test_context.device.is_cuda:
             raise SkipTest('Device is not a CUDA device')
         return test(*args, **kwargs)
-    return wrapper
+    return wrapper     # type: ignore
 
 
 @decorator
-def force_autotune(test, *args, **kw):
+def force_autotune(test: Callable[..., _T], *args, **kw) -> _T:
     """Decorator that disables autotuning for a test. Instead, the test
     value specified for each class is returned."""
     with mock.patch('katsdpsigproc.tune.autotuner_impl', new=tune.force_autotuner):
@@ -105,13 +111,13 @@ device_test.__test__ = False         # type: ignore
 cuda_test.__test__ = False           # type: ignore
 
 
-class TestLinenoLexer(object):
-    def test_escape_filename(self):
+class TestLinenoLexer:
+    def test_escape_filename(self) -> None:
         assert_equal(
             r'"abc\"def\\ghi"',
             LinenoLexer._escape_filename(r'abc"def\ghi'))
 
-    def test_render(self):
+    def test_render(self) -> None:
         source = "line 1\nline 2\nline 3"
         out = Template(source, lexer_cls=LinenoLexer).render()
         assert_equal(dedent(
@@ -125,31 +131,32 @@ class TestLinenoLexer(object):
             """), out)
 
 
-class TestHostArray(object):
-    cls = HostArray
+class TestHostArray:
+    cls = HostArray      # type: Type[HostArray]
 
-    def allocate(self, shape, dtype, padded_shape):
+    def allocate(self, shape: Tuple[int, ...], dtype: np.dtype,
+                 padded_shape: Tuple[int, ...]) -> HostArray:
         return self.cls(shape, dtype, padded_shape)
 
-    def setup(self):
+    def setup(self) -> None:
         self.shape = (17, 13)
         self.padded_shape = (32, 16)
         self.constructed = self.allocate(self.shape, np.int32, self.padded_shape)
         self.view = np.zeros(self.padded_shape)[2:4, 3:5].view(self.cls)
         self.sliced = self.constructed[2:4, 3:5]
 
-    def test_safe(self):
+    def test_safe(self) -> None:
         assert self.cls.safe(self.constructed)
         assert not self.cls.safe(self.view)
         assert not self.cls.safe(self.sliced)
         assert not self.cls.safe(np.zeros(self.shape))
 
 
-class TestDeviceArray(object):
-    cls = DeviceArray
+class TestDeviceArray:
+    cls = DeviceArray      # type: Type[DeviceArray]
 
     @device_test
-    def setup(self, context, queue):
+    def setup(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         self.shape = (17, 13)
         self.padded_shape = (32, 16)
         self.strides = (64, 4)
@@ -160,18 +167,18 @@ class TestDeviceArray(object):
             padded_shape=self.padded_shape)
 
     @device_test
-    def test_strides(self, context, queue):
+    def test_strides(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         assert_equal(self.strides, self.array.strides)
 
     @device_test
-    def test_empty_like(self, context, queue):
+    def test_empty_like(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         ary = self.array.empty_like()
         assert_equal(self.shape, ary.shape)
         assert_equal(self.strides, ary.strides)
         assert HostArray.safe(ary)
 
     @device_test
-    def test_set_get(self, context, queue):
+    def test_set_get(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         ary = np.random.randint(0, 100, self.shape).astype(np.int32)
         self.array.set(queue, ary)
         # Read back results, check that it matches
@@ -182,6 +189,7 @@ class TestDeviceArray(object):
             with context:
                 pycuda.driver.memcpy_dtoh(buf, self.array.buffer.gpudata)
         else:
+            assert isinstance(queue, opencl.CommandQueue)
             pyopencl.enqueue_copy(
                 queue._pyopencl_command_queue,
                 buf, self.array.buffer.data)
@@ -192,10 +200,10 @@ class TestDeviceArray(object):
         np.testing.assert_equal(ary, buf)
 
     def _test_copy_region(
-            self, context, queue,
-            src_shape, src_padded_shape,
-            dest_shape, dest_padded_shape,
-            src_region, dest_region):
+            self, context: AbstractContext, queue: AbstractCommandQueue,
+            src_shape: Tuple[int, ...], src_padded_shape: Optional[Tuple[int, ...]],
+            dest_shape: Tuple[int, ...], dest_padded_shape: Optional[Tuple[int, ...]],
+            src_region: accel._Slice, dest_region: accel._Slice) -> None:
         # copy_region test
         dtype = np.int32
         src = self.cls(context, src_shape, dtype, src_padded_shape)
@@ -223,7 +231,7 @@ class TestDeviceArray(object):
         np.testing.assert_array_equal(expected, h_dest)
 
     @device_test
-    def test_copy_region_4d(self, context, queue):
+    def test_copy_region_4d(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         self._test_copy_region(
             context, queue,
             (7, 5, 12, 19), (8, 9, 14, 25),
@@ -231,41 +239,45 @@ class TestDeviceArray(object):
             np.s_[2:4, :, 3:7:2, 10:], np.s_[1:3, 0:5, 4:8:2, 10:])
 
     @device_test
-    def test_copy_region_0d(self, context, queue):
+    def test_copy_region_0d(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         self._test_copy_region(context, queue, (), (), (), (), (), ())
 
     @device_test
-    def test_copy_region_1d(self, context, queue):
+    def test_copy_region_1d(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         self._test_copy_region(
             context, queue, (3, 5), (4, 6), (5, 7), (7, 10),
             np.s_[1, 0:3], np.s_[2, 1:4])
 
     @device_test
-    def test_copy_region_2d(self, context, queue):
+    def test_copy_region_2d(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         self._test_copy_region(
             context, queue, (3, 5), (4, 6), (5, 7), (7, 10),
             np.s_[:1, 0:3], np.s_[-1:, 1:4])
 
     @device_test
-    def test_copy_region_missing_axes(self, context, queue):
+    def test_copy_region_missing_axes(self, context: AbstractContext,
+                                      queue: AbstractCommandQueue) -> None:
         self._test_copy_region(
             context, queue, (3, 5), (4, 6), (5, 5), (7, 10),
             np.s_[:1], np.s_[-1:])
 
     @device_test
-    def test_copy_region_newaxis(self, context, queue):
+    def test_copy_region_newaxis(self, context: AbstractContext,
+                                 queue: AbstractCommandQueue) -> None:
         self._test_copy_region(
             context, queue, (10,), None, (10, 10), None,
             np.s_[np.newaxis, 4:6], np.s_[:1, 7:9])
 
     @device_test
-    def test_copy_region_negative(self, context, queue):
+    def test_copy_region_negative(self, context: AbstractContext,
+                                  queue: AbstractCommandQueue) -> None:
         self._test_copy_region(
             context, queue, (10, 12), None, (7, 8), None,
             np.s_[-4, -3:-1], np.s_[-7, -8:-4:2])
 
     @device_test
-    def test_copy_region_errors(self, context, queue):
+    def test_copy_region_errors(self, context: AbstractContext,
+                                queue: AbstractCommandQueue) -> None:
         # Too many axes
         with assert_raises(IndexError):
             self._test_copy_region(
@@ -293,7 +305,7 @@ class TestDeviceArray(object):
                 np.s_[3:0:-1], np.s_[4:1:-1])
 
     @device_test
-    def test_zero(self, context, queue):
+    def test_zero(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         ary = np.random.randint(0x12345678, 0x23456789, self.shape).astype(np.int32)
         self.array.set(queue, ary)
         before = self.array.get(queue)
@@ -302,11 +314,11 @@ class TestDeviceArray(object):
         np.testing.assert_equal(ary, before)
         assert_equal(0, np.max(after))
 
-    def _allocate_raw(self, context, n_bytes):
+    def _allocate_raw(self, context: AbstractContext, n_bytes: int) -> Any:
         return context.allocate_raw(n_bytes)
 
     @device_test
-    def test_raw(self, context, queue):
+    def test_raw(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         raw = self._allocate_raw(context, 2048)
         ary = self.cls(
             context=context,
@@ -331,53 +343,55 @@ class TestDeviceArray(object):
 class TestPinnedAMD(TestDeviceArray):
     """Run DeviceArray tests forcing `_PinnedAMD` class for pinned memory."""
     @device_test
-    def setup(self, context, device):
-        context._force_pinned_amd = True
+    def setup(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
+        context._force_pinned_amd = True        # type: ignore
         super(TestPinnedAMD, self).setup()
 
     @device_test
-    def teardown(self, context, device):
-        context._force_pinned_amd = False
+    def teardown(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
+        context._force_pinned_amd = False       # type: ignore
 
 
 class TestSVMArrayHost(TestHostArray):
     """Tests SVMArray using the HostArray tests"""
+
     cls = SVMArray
 
-    def allocate(self, shape, dtype, padded_shape):
+    def allocate(self, shape: Tuple[int, ...], dtype: np.dtype,
+                 padded_shape: Tuple[int, ...]) -> SVMArray:
         return self.cls(self.context, shape, dtype, padded_shape)
 
     @device_test
     @cuda_test
-    def setup(self, context, queue):
+    def setup(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         self.context = context
         super(TestSVMArrayHost, self).setup()
 
 
 class TestSVMArray(TestDeviceArray):
     """Tests SVMArray using the DeviceArray tests, plus some new ones"""
+
     cls = SVMArray
 
-    def _allocate_raw(self, context, n_bytes):
+    def _allocate_raw(self, context: AbstractContext, n_bytes: int) -> object:
         return context.allocate_svm_raw(n_bytes)
 
     @device_test
     @cuda_test
-    def setup(self, context, queue):
+    def setup(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         super(TestSVMArray, self).setup()
 
     @device_test
     @cuda_test
-    def test_coherence(self, context, queue):
-        """Check that runtime correct transfers data between the host and
-        device views."""
+    def test_coherence(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
+        """Check that runtime correct transfers data between the host and device views."""
         source = """\
             <%include file="/port.mako"/>
             KERNEL void triple(unsigned int *data)
             {
                 data[get_global_id(0)] *= 3;
             }"""
-        program = accel.build(context, None, source=source)
+        program = accel.build(context, 'not a file', source=source)
         kernel = program.get_kernel("triple")
         ary = SVMArray(context, (123,), np.uint32, (128,))
         ary[:] = np.arange(123, dtype=np.uint32)
@@ -386,10 +400,10 @@ class TestSVMArray(TestDeviceArray):
         np.testing.assert_equal(np.arange(369, step=3, dtype=np.uint32), ary)
 
 
-class TestSVMAllocator(object):
+class TestSVMAllocator:
     @device_test
     @cuda_test
-    def test_allocate(self, context, queue):
+    def test_allocate(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         allocator = accel.SVMAllocator(context)
         ary = allocator.allocate((12, 34), np.int32, (13, 35))
         assert isinstance(ary, accel.SVMArray)
@@ -400,7 +414,7 @@ class TestSVMAllocator(object):
 
     @device_test
     @cuda_test
-    def test_allocate_raw(self, context, queue):
+    def test_allocate_raw(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         allocator = accel.SVMAllocator(context)
         raw = allocator.allocate_raw(13 * 35 * 4)
         ary = allocator.allocate((12, 34), np.int32, (13, 35), raw=raw)
@@ -411,9 +425,10 @@ class TestSVMAllocator(object):
         ary.fill(1)  # Just to make sure it doesn't crash
 
 
-class TestDimension(object):
+class TestDimension:
     """Tests for :class:`katsdpsigproc.accel.Dimension`"""
-    def test_is_power2(self):
+
+    def test_is_power2(self) -> None:
         assert accel.Dimension._is_power2(1)
         assert accel.Dimension._is_power2(2)
         assert accel.Dimension._is_power2(32)
@@ -422,14 +437,14 @@ class TestDimension(object):
         assert not accel.Dimension._is_power2(3)
         assert not accel.Dimension._is_power2(5)
 
-    def test_min_padded_round(self):
+    def test_min_padded_round(self) -> None:
         """Constructor computes min padded size correctly"""
         dim = accel.Dimension(17, min_padded_round=4)
         assert_equal(20, dim.min_padded_size)
         dim = accel.Dimension(20, min_padded_round=5)
         assert_equal(20, dim.min_padded_size)
 
-    def test_add_align_dtype(self):
+    def test_add_align_dtype(self) -> None:
         dim = accel.Dimension(20, alignment=8)
         assert_equal(8, dim.alignment)
         dim.add_align_dtype(np.complex64)
@@ -439,7 +454,7 @@ class TestDimension(object):
         dim.add_align_dtype(np.float32)
         assert_equal(accel.Dimension.ALIGN_BYTES, dim.alignment_hint)
 
-    def test_valid(self):
+    def test_valid(self) -> None:
         """Test `valid` method on non-exact dimension"""
         dim = accel.Dimension(17, min_padded_round=8, alignment=4)
         assert dim.valid(24)
@@ -447,7 +462,7 @@ class TestDimension(object):
         assert dim.valid(28)
         assert not dim.valid(30)
 
-    def test_valid_exact(self):
+    def test_valid_exact(self) -> None:
         """Test `valid` method on exact dimension"""
         dim = accel.Dimension(20, alignment=4, exact=True)
         assert dim.valid(20)
@@ -458,16 +473,15 @@ class TestDimension(object):
         assert not dim.valid(20)
 
     @classmethod
-    def assert_dimensions_equal(cls, dim1, dim2):
+    def assert_dimensions_equal(cls, dim1: accel.Dimension, dim2: accel.Dimension) -> None:
         assert_equal(dim1.size, dim2.size)
         assert_equal(dim1.min_padded_size, dim2.min_padded_size)
         assert_equal(dim1.alignment, dim2.alignment)
         assert_equal(dim1.alignment_hint, dim2.alignment_hint)
         assert_equal(dim1.exact, dim2.exact)
 
-    def test_link(self):
-        """Linking several dimensions together gives them all the right
-        properties."""
+    def test_link(self) -> None:
+        """Linking several dimensions together gives them all the right properties."""
         dim1 = accel.Dimension(22, min_padded_size=28, alignment=4)
         dim2 = accel.Dimension(22, min_padded_size=24, alignment=8, align_dtype=np.int32)
         dim3 = accel.Dimension(22, min_padded_size=22, align_dtype=np.uint16)
@@ -481,7 +495,7 @@ class TestDimension(object):
         assert_equal(accel.Dimension.ALIGN_BYTES // 2, dim1.alignment_hint)
         assert_equal(False, dim1.exact)
 
-    def test_link_bad_size(self):
+    def test_link_bad_size(self) -> None:
         """Linking dimensions with different sizes fails"""
         dim1 = accel.Dimension(22, min_padded_size=28, alignment=4)
         dim2 = accel.Dimension(23, min_padded_size=24, alignment=8, align_dtype=np.int32)
@@ -489,7 +503,7 @@ class TestDimension(object):
             dim1.link(dim2)
         assert dim1._root() is not dim2._root()
 
-    def test_link_bad_exact(self):
+    def test_link_bad_exact(self) -> None:
         """Linking dimensions into an unsatisfiable requirement fails"""
         dim1 = accel.Dimension(22, exact=True)
         dim2 = accel.Dimension(22, min_padded_size=28)
@@ -502,36 +516,37 @@ class TestDimension(object):
         assert dim1._root() is not dim2._root()
         assert dim1._root() is not dim3._root()
 
-    def test_required_padded_size(self):
+    def test_required_padded_size(self) -> None:
         """The padded size is computed correctly"""
         dim = accel.Dimension(30, 7, alignment=4)
         assert_equal(36, dim.required_padded_size())
 
-    def test_required_padded_size_dtype(self):
+    def test_required_padded_size_dtype(self) -> None:
         """The padded size is computed correctly when an alignment hint is given"""
         dim = accel.Dimension(1100, 200, align_dtype=np.float32)
         assert_equal(1216, dim.required_padded_size())
 
-    def test_required_padded_size_exact(self):
+    def test_required_padded_size_exact(self) -> None:
         """The padded size is computed correctly for exact dimensions"""
         dim = accel.Dimension(1100, align_dtype=np.float32, exact=True)
         assert_equal(1100, dim.required_padded_size())
 
-    def test_required_padded_size_small(self):
+    def test_required_padded_size_small(self) -> None:
         """The alignment hint is ignored for small sizes"""
         dim = accel.Dimension(18, alignment=8, align_dtype=np.uint8)
         assert_equal(24, dim.required_padded_size())
 
 
-class TestIOSlot(object):
+class TestIOSlot:
     """Tests for :class:`katsdpsigproc.accel.IOSlot`"""
+
     @mock.patch('katsdpsigproc.accel.DeviceArray', spec=True)
-    def test_allocate(self, DeviceArray):
+    def test_allocate(self, DeviceArray: mock.Mock) -> None:
         """IOSlot.allocate must correctly allocate a buffer"""
-        dims = [
+        dims = (
             accel.Dimension(50, min_padded_size=60, alignment=8),
             accel.Dimension(30, min_padded_size=50, alignment=4)
-        ]
+        )
         shape = (50, 30)
         padded_shape = (64, 52)
         dtype = np.dtype(np.uint8)
@@ -555,7 +570,7 @@ class TestIOSlot(object):
         assert dims[1].alignment_hint == accel.Dimension.ALIGN_BYTES
 
     @mock.patch('katsdpsigproc.accel.DeviceArray', spec=True)
-    def test_allocate_raw(self, DeviceArray):
+    def test_allocate_raw(self, DeviceArray: mock.Mock) -> None:
         """Test IOSlot.allocate with a raw parameter"""
         shape = (50, 30)
         dtype = np.dtype(np.float32)
@@ -577,7 +592,7 @@ class TestIOSlot(object):
         DeviceArray.assert_called_once_with(
             mock.sentinel.context, shape, dtype, shape, raw)
 
-    def test_validate_shape(self):
+    def test_validate_shape(self) -> None:
         """IOSlot.validate must check that the shape matches"""
         ary = mock.sentinel.ary
         ary.dtype = np.float32
@@ -595,7 +610,7 @@ class TestIOSlot(object):
             ary.shape = (5,)
             slot.bind(ary)
 
-    def test_validate_dtype(self):
+    def test_validate_dtype(self) -> None:
         """IOSlot.validate must check that the dtype matches"""
         ary = mock.sentinel.ary
         ary.dtype = np.float32
@@ -611,7 +626,7 @@ class TestIOSlot(object):
             ary.dtype = np.int32
             slot.bind(ary)
 
-    def test_validate_padded_shape(self):
+    def test_validate_padded_shape(self) -> None:
         """IOSlot.validate must check that the padded shape is valid"""
         ary = mock.sentinel.ary
         ary.dtype = np.float32
@@ -625,13 +640,13 @@ class TestIOSlot(object):
             # Bigger than needed, but not an exact match - must fail
             slot.bind(ary)
 
-    def test_required_bytes(self):
+    def test_required_bytes(self) -> None:
         slot = accel.IOSlot(
             (accel.Dimension(27, alignment=4), accel.Dimension(33, alignment=32)),
             np.float32)
         assert_equal(4 * 28 * 64, slot.required_bytes())
 
-    def test_bind_none(self):
+    def test_bind_none(self) -> None:
         """IOSlot.bind must accept `None`"""
         ary = mock.sentinel.ary
         ary.dtype = np.float32
@@ -644,43 +659,43 @@ class TestIOSlot(object):
         assert slot.buffer is None
 
 
-class TestCompoundIOSlot(object):
+class TestCompoundIOSlot:
     """Tests for :class:`katsdpsigproc.accel.CompoundIOSlot`"""
 
-    def setup(self):
-        self.dims1 = [
+    def setup(self) -> None:
+        self.dims1 = (
             accel.Dimension(13, min_padded_size=17, alignment=1),
             accel.Dimension(7, min_padded_size=8, alignment=8),
             accel.Dimension(22, min_padded_size=25, alignment=4)
-        ]
-        self.dims2 = [
+        )
+        self.dims2 = (
             accel.Dimension(13, min_padded_size=14, alignment=4),
             accel.Dimension(7, min_padded_size=10, alignment=4),
             accel.Dimension(22, min_padded_size=22, alignment=1)
-        ]
+        )
         self.slot1 = accel.IOSlot(self.dims1, np.float32)
         self.slot2 = accel.IOSlot(self.dims2, np.float32)
 
-    def test_check_empty(self):
+    def test_check_empty(self) -> None:
         """CompoundIOSlot constructor must reject empty list"""
         with assert_raises(ValueError):
             accel.CompoundIOSlot([])
 
-    def test_validate_shape(self):
+    def test_validate_shape(self) -> None:
         """CompoundIOSlot must check that children have consistent shapes"""
         slot1 = accel.IOSlot((5, 3), np.float32)
         slot2 = accel.IOSlot((5, 4), np.float32)
         with assert_raises(ValueError):
             accel.CompoundIOSlot([slot1, slot2])
 
-    def test_validate_dtype(self):
+    def test_validate_dtype(self) -> None:
         """CompoundIOSlot must check that children have consistent data types"""
         slot1 = accel.IOSlot((5, 3), np.float32)
         slot2 = accel.IOSlot((5, 3), np.int32)
         with assert_raises(TypeError):
             accel.CompoundIOSlot([slot1, slot2])
 
-    def test_attributes(self):
+    def test_attributes(self) -> None:
         """CompoundIOSlot must correctly combine attributes"""
         slot = accel.CompoundIOSlot([self.slot1, self.slot2])
         assert_equal((13, 7, 22), slot.shape)
@@ -694,7 +709,7 @@ class TestCompoundIOSlot(object):
         for x, y in zip(self.dims1, self.dims2):
             TestDimension.assert_dimensions_equal(x, y)
 
-    def test_bind(self):
+    def test_bind(self) -> None:
         """CompoundIOSlot.bind must bind children"""
         ary = mock.sentinel.ary
         ary.shape = (13, 7, 22)
@@ -706,7 +721,7 @@ class TestCompoundIOSlot(object):
         assert_equal(ary, self.slot1.buffer)
         assert_equal(ary, self.slot2.buffer)
 
-    def test_bind_fail(self):
+    def test_bind_fail(self) -> None:
         """CompoundIOSlot.bind must not have side effects if the array is not
         valid for all children.
         """
@@ -727,18 +742,18 @@ class TestCompoundIOSlot(object):
         assert self.slot2.buffer is None
 
 
-class TestAliasIOSlot(object):
+class TestAliasIOSlot:
     """Tests for :class:`katsdpsigproc.accel.AliasIOSlot`"""
 
-    def setup(self):
+    def setup(self) -> None:
         self.slot1 = accel.IOSlot((3, 7), np.float32)
         self.slot2 = accel.IOSlot((5, 3), np.complex64)
 
-    def test_required_bytes(self):
+    def test_required_bytes(self) -> None:
         slot = accel.AliasIOSlot([self.slot1, self.slot2])
         assert_equal(120, slot.required_bytes())
 
-    def test_allocate(self):
+    def test_allocate(self) -> None:
         # Set up mocks
         raw = mock.sentinel.raw
         context = mock.NonCallableMock()
@@ -754,7 +769,7 @@ class TestAliasIOSlot(object):
         assert self.slot2.buffer is not None
 
 
-class TestVisualizeOperation(object):
+class TestVisualizeOperation:
     """Tests for :class:`katsdpsigproc.accel.visualize_operation`.
 
     This is just a basic smoke test to ensure that it runs without crashing.
@@ -764,14 +779,14 @@ class TestVisualizeOperation(object):
         def _run(self) -> None:
             pass
 
-    def setup(self):
+    def setup(self) -> None:
         self.tmpdir = tempfile.mkdtemp()
 
-    def teardown(self):
+    def teardown(self) -> None:
         shutil.rmtree(self.tmpdir)
 
     @device_test
-    def test(self, context, queue):
+    def test(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         inner = TestVisualizeOperation.Inner(queue)
         inner.slots['foo'] = accel.IOSlot((3, 4), np.float32)
         inner.slots['bar'] = accel.IOSlot((4, 3), np.float32)

--- a/katsdpsigproc/transpose.py
+++ b/katsdpsigproc/transpose.py
@@ -1,23 +1,26 @@
 """On-device transposition of 2D arrays"""
 
-from __future__ import division, print_function, absolute_import
+from typing import Tuple, Optional, Mapping, Callable, Any
+
 import numpy as np
+
 from . import accel
 from . import tune
+from .abc import AbstractContext, AbstractCommandQueue
 
 
-class TransposeTemplate(object):
+class TransposeTemplate:
     """Kernel for transposing a 2D array of data
 
     Parameters
     ----------
-    context : |Context|
+    context
         Context for which kernels will be compiled
-    dtype : numpy dtype
+    dtype
         Type of data elements
-    ctype : str
+    ctype
         Type (in C/CUDA, not numpy) of data elements
-    tuning : dict, optional
+    tuning
         Kernel tuning parameters; if omitted, will autotune. The possible
         parameters are
 
@@ -27,7 +30,8 @@ class TransposeTemplate(object):
 
     autotune_version = 1
 
-    def __init__(self, context, dtype, ctype, tuning=None):
+    def __init__(self, context: AbstractContext, dtype: np.dtype, ctype: str,
+                 tuning: Optional[Mapping[str, Any]] = None) -> None:
         self.context = context
         self.dtype = np.dtype(dtype)
         self.ctype = ctype
@@ -45,14 +49,14 @@ class TransposeTemplate(object):
 
     @classmethod
     @tune.autotuner(test={'block': 8, 'vtx': 2, 'vty': 3})
-    def autotune(cls, context, dtype, ctype):
+    def autotune(cls, context: AbstractContext, dtype: np.dtype, ctype: str) -> Mapping[str, Any]:
         queue = context.create_tuning_command_queue()
         in_shape = (2048, 2048)
         out_shape = (2048, 2048)
         in_data = accel.DeviceArray(context, in_shape, dtype=dtype)
         out_data = accel.DeviceArray(context, out_shape, dtype=dtype)
 
-        def generate(block, vtx, vty):
+        def generate(block: int, vtx: int, vty: int) -> Optional[Callable[[int], float]]:
             local_mem = (block * vtx + 1) * (block * vty) * np.dtype(dtype).itemsize
             if local_mem > 32768:
                 # Skip configurations using lots of lmem
@@ -69,8 +73,9 @@ class TransposeTemplate(object):
                              vtx=[1, 2, 3, 4],
                              vty=[1, 2, 3, 4])
 
-    def instantiate(self, *args, **kwargs):
-        return Transpose(self, *args, **kwargs)
+    def instantiate(self, command_queue: AbstractCommandQueue, shape: Tuple[int, ...],
+                    allocator: Optional[accel.AbstractAllocator] = None) -> 'Transpose':
+        return Transpose(self, command_queue, shape, allocator)
 
 
 class Transpose(accel.Operation):
@@ -84,7 +89,8 @@ class Transpose(accel.Operation):
     **dest**
         Output
     """
-    def __init__(self, template, command_queue, shape, allocator=None):
+    def __init__(self, template: TransposeTemplate, command_queue: AbstractCommandQueue,
+                 shape: Tuple[int, ...], allocator: Optional[accel.AbstractAllocator] = None):
         super(Transpose, self).__init__(command_queue, allocator)
         self.template = template
         self.kernel = template.program.get_kernel("transpose")
@@ -92,7 +98,7 @@ class Transpose(accel.Operation):
         self.slots['src'] = accel.IOSlot(shape, template.dtype)
         self.slots['dest'] = accel.IOSlot((shape[1], shape[0]), template.dtype)
 
-    def _run(self):
+    def _run(self) -> None:
         src = self.buffer('src')
         dest = self.buffer('dest')
         # Round up to number of blocks in each dimension
@@ -109,9 +115,9 @@ class Transpose(accel.Operation):
             global_size=(in_col_tiles * self.template._block, in_row_tiles * self.template._block),
             local_size=(self.template._block, self.template._block))
 
-    def parameters(self):
+    def parameters(self) -> Mapping[str, Any]:
         return {
             'dtype': self.template.dtype,
             'ctype': self.template.ctype,
-            'shape': self.slots['src'].shape
+            'shape': self.slots['src'].shape      # type: ignore
         }

--- a/katsdpsigproc/tune.py
+++ b/katsdpsigproc/tune.py
@@ -316,9 +316,9 @@ def autotune(generate: Callable[..., Optional[_ScoreFunc]], time_limit: float = 
         if the Cartesian product is empty
     """
     opts = itertools.product(*kwargs.values())
-    best: Optional[Mapping[str, Any]] = None
-    best_score: Optional[float] = None
-    exc: Optional[Exception] = None
+    best = None                # type: Optional[Mapping[str, Any]]
+    best_score = None          # type: Optional[float]
+    exc = None                 # type: Optional[Exception]
     if threads is None:
         try:
             threads = multiprocessing.cpu_count()

--- a/katsdpsigproc/tune.py
+++ b/katsdpsigproc/tune.py
@@ -33,20 +33,37 @@ import time
 import logging
 import multiprocessing
 import concurrent.futures
+from typing import Dict, Sequence, Mapping, Callable, Optional, Type, TypeVar, Any, cast
 
 import appdirs
 import sqlite3
 import numpy as np
 from decorator import decorator
+from typing_extensions import Protocol
+
+from .abc import AbstractContext, AbstractTuningCommandQueue
 
 
 _logger = logging.getLogger(__name__)
+_ScoreFunc = Callable[[int], float]
+_T = TypeVar('_T')
 
 
-def adapt_value(value):
-    """Converts `value` to a type that can be used in sqlite3. This is
-    not done through the sqlite3 adapter interface, because that is global
-    rather than per-connection. This also only applies to lookup keys,
+class _TuningFunc(Protocol):
+    @property
+    def __name__(self) -> str:
+        ...
+
+    def __call__(self, __cls: Type, __context: AbstractContext,
+                 *args: Any, **kwargs: Any) -> Mapping[str, Any]:
+        ...
+
+
+def adapt_value(value: Any) -> Any:
+    """Converts `value` to a type that can be used in sqlite3.
+
+    This is not done through the sqlite3 adapter interface, because that is
+    global rather than per-connection. This also only applies to lookup keys,
     not results, because it is not a symmetric relationship.
     """
     if isinstance(value, type) or isinstance(value, np.dtype):
@@ -56,9 +73,12 @@ def adapt_value(value):
     return value
 
 
-def _db_keys(fn, args, kwargs):
-    """Uses the arguments passed to an autotuning function (see
-    :function:`autotuner`) to generate a database key.
+def _db_keys(fn: _TuningFunc, args: Sequence, kwargs: Mapping) -> Dict[str, Any]:
+    """Uses the arguments passed to an autotuning function to generate a database key.
+
+    .. seealso::
+
+       :func:`autotuner`
     """
     argspec = inspect.getargspec(fn)
     # Extract the arguments passed to the wrapped function, by name
@@ -75,17 +95,19 @@ def _db_keys(fn, args, kwargs):
     return keys
 
 
-def _query(conn, tablename, keys):
-    """Fetch a cached record from the database. If the record is not found,
-    it will return None.
+def _query(conn: sqlite3.Connection, tablename: str,
+           keys: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
+    """Fetch a cached record from the database.
+
+    If the record is not found, it will return None.
 
     Parameters
     ----------
-    conn : sqlite3.Connection
+    conn
         Database connection
-    tablename : str
+    tablename
         Name of the table to query
-    keys : mapping
+    keys
         Keys and values for the query
     """
     try:
@@ -115,7 +137,8 @@ def _query(conn, tablename, keys):
     return None
 
 
-def _create_table(conn, tablename, keys, values):
+def _create_table(conn: sqlite3.Connection, tablename: str,
+                  keys: Mapping[str, Any], values: Mapping[str, Any]) -> None:
     command = 'CREATE TABLE IF NOT EXISTS {0} ('.format(tablename)
     for name in itertools.chain(keys.keys(), values.keys()):
         command += name + ' NOT NULL, '
@@ -123,7 +146,8 @@ def _create_table(conn, tablename, keys, values):
     conn.execute(command)
 
 
-def _save(conn, tablename, keys, values):
+def _save(conn: sqlite3.Connection, tablename: str,
+          keys: Mapping[str, Any], values: Mapping[str, Any]) -> None:
     """Write cached result into the table, creating it if it does not already
     exist.
     """
@@ -141,7 +165,7 @@ def _save(conn, tablename, keys, values):
         cursor.execute(command, list(entries.values()))
 
 
-def _open_db():
+def _open_db() -> sqlite3.Connection:
     cache_dir = appdirs.user_cache_dir('katsdpsigproc', 'ska-sa')
     try:
         os.makedirs(cache_dir)
@@ -155,16 +179,20 @@ def _open_db():
     return conn
 
 
-def _close_db(conn):
+def _close_db(conn: sqlite3.Connection) -> None:
     """Close a database. This is split into a separate function for the benefit
     of testing, because the close member of the object itself is read-only and
     hence cannot be patched."""
     conn.close()
 
 
-def autotuner_impl(test, fn, *args, **kwargs):
-    """Implementation of :func:`autotuner`. It is split into a separate
-    function so that mocks can patch it."""
+def autotuner_impl(test: Mapping[str, Any],
+                   fn: _TuningFunc,
+                   *args: Any, **kwargs: Any) -> Mapping[str, Any]:
+    """Implementation of :func:`autotuner`.
+
+    It is split into a separate function so that mocks can patch it.
+    """
     cls = args[0]
     classname = '{0}.{1}.{2}'.format(cls.__module__, cls.__name__, fn.__name__)
     tablename = classname.replace('.', '_') + \
@@ -188,7 +216,7 @@ def autotuner_impl(test, fn, *args, **kwargs):
     return ans
 
 
-def autotuner(test):
+def autotuner(test: Mapping[str, Any]) -> Callable[[_T], _T]:
     r"""Decorator that marks a function as an autotuning function and caches
     the result. The function must take a class and a context as the first
     two arguments. The remaining arguments form a cache key, along with
@@ -203,7 +231,7 @@ def autotuner(test):
         A value that will be returned by :func:`stub_autotuner`.
     """
     @decorator
-    def autotuner(fn, *args, **kwargs):
+    def autotuner(fn: _TuningFunc, *args: Any, **kwargs: Any) -> Mapping[str, Any]:
         r"""Decorator that marks a function as an autotuning function and caches
         the result. The function must take a class and a context as the first
         two arguments. The remaining arguments form a cache key, along with
@@ -213,28 +241,35 @@ def autotuner(test):
         \*args construct may not be used.
         """
         return autotuner_impl(test, fn, *args, **kwargs)
-    return autotuner
+    # decorator module doesn't have type annotations, so we need to force it
+    return cast(Callable[[_T], _T], autotuner)
 
 
-def force_autotuner(test, fn, *args, **kwargs):
-    """Drop-in replacement for :func:`autotuner_impl` that does not do any
-    caching. It is intended to be used with a mocking framework.
+def force_autotuner(test: Mapping[str, Any], fn: _TuningFunc,
+                    *args: Any, **kwargs: Any) -> Mapping[str, Any]:
+    """Drop-in replacement for :func:`autotuner_impl` that does not do any caching.
+
+    It is intended to be used with a mocking framework.
     """
     return fn(*args, **kwargs)
 
 
-def stub_autotuner(test, fn, *args, **kwargs):
-    """Drop-in replacement for :func:`autotuner_impl` that does not do
-    any tuning, but instead returns the provided value. It is intended to be
+def stub_autotuner(test: Mapping[str, Any], fn: _TuningFunc,
+                   *args: Any, **kwargs: Any) -> Mapping[str, Any]:
+    """Drop-in replacement for :func:`autotuner_impl` that does not do any tuning.
+
+    It instead returns the provided value. It is intended to be
     used with a mocking framework."""
     return test
 
 
-def make_measure(queue, function):
-    """Generates a measurement function that can be returned by the
-    function passed to :func:`autotune`. It calls `function`
-    (with no arguments) the appropriate number of times and returns
-    the averaged elapsed time as measured by `queue`."""
+def make_measure(queue: AbstractTuningCommandQueue, function: Callable[[], None]) -> _ScoreFunc:
+    """Generates a measurement function.
+
+    The result can be returned by the function passed to :func:`autotune`. It
+    calls `function` (with no arguments) the appropriate number of times and
+    returns the averaged elapsed time as measured by `queue`.
+    """
     def measure(iters):
         queue.start_tuning()
         for i in range(iters):
@@ -243,9 +278,9 @@ def make_measure(queue, function):
     return measure
 
 
-def autotune(generate, time_limit=0.1, threads=None, **kwargs):
-    """Run a number of tuning experiments and find the optimal combination
-    of parameters.
+def autotune(generate: Callable[..., Optional[_ScoreFunc]], time_limit: float = 0.1,
+             threads: Optional[int] = None, **kwargs: Any) -> Mapping[str, Any]:
+    """Run a number of tuning experiments and find the optimal combination of parameters.
 
     Each argument is a iterable. The `generate` function is passed each
     element of the Cartesian product (by keyword), and returns a callable.
@@ -265,24 +300,25 @@ def autotune(generate, time_limit=0.1, threads=None, **kwargs):
 
     Parameters
     ----------
-    generate : callable
+    generate
         function that creates a scoring function
-    time_limit : float
+    time_limit
         amount of time to spend testing each configuration (excluding setup time)
-    threads : int, optional
+    threads
         number of parallel calls to `generate` to make at a time (defaults to
         CPU count)
 
     Raises
     ------
-    Exception : if every combination throws an exception, the last exception
-        is re-raised.
-    ValueError : if the Cartesian product is empty
+    Exception
+        if every combination throws an exception, the last exception is re-raised.
+    ValueError
+        if the Cartesian product is empty
     """
     opts = itertools.product(*kwargs.values())
-    best = None
-    best_score = None
-    exc = None
+    best: Optional[Mapping[str, Any]] = None
+    best_score: Optional[float] = None
+    exc: Optional[Exception] = None
     if threads is None:
         try:
             threads = multiprocessing.cpu_count()

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+python_version = 3.5
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ python-dateutil            # Needed by Pandas
 pytools
 pytz                       # Needed by Pandas
 scipy
+typing_extensions==3.7.4.1

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
         "numba>=0.36.1",   # Older versions have bugs in median functions
         "decorator",
         "mako",
-        "appdirs"
+        "appdirs",
+        "typing_extensions"
     ],
     extras_require={
         "CUDA": ["pycuda>=2015.1.3"],


### PR DESCRIPTION
Sprinkles more type annotations around. There is one major functional change: `Operation.buffer` now raises an exception if there is no buffer bound, rather than returning None. It's pretty much always called with a static string for which a buffer is known to be present, so I don't expect this to cause much if any breakage, and it allows the return type to be `DeviceArray` instead of `Optional[DeviceArray]`.