### PR TITLE
Another round of type annotations

### DIFF
--- a/katsdpsigproc/resource.py
+++ b/katsdpsigproc/resource.py
@@ -160,7 +160,7 @@ class Resource(Generic[_T]):
         handle that can be used to acquire and release it later. Acquisitions
         always occur in the order in which calls to :meth:`acquire` are made.
 
-        See :class:`ResourceAcquisition` for further details.
+        See :class:`ResourceAllocation` for further details.
         """
         old = self._future
         self._future = asyncio.Future(loop=self._loop)

--- a/katsdpsigproc/test/test_fill.py
+++ b/katsdpsigproc/test/test_fill.py
@@ -1,24 +1,28 @@
+from typing import cast
+
 import numpy as np
 
 from .test_accel import device_test, force_autotune
 from .. import accel
 from .. import fill
+from ..abc import AbstractContext, AbstractCommandQueue
 
 
-class TestFill(object):
+class TestFill:
     @classmethod
-    def pad_dimension(cls, dim, extra):
+    def pad_dimension(cls, dim: accel.Dimension, extra: int) -> None:
         """Modifies `dim` to have at least `extra` padding"""
         newdim = accel.Dimension(dim.size, min_padded_size=dim.size + extra)
         newdim.link(dim)
 
     @device_test
-    def test_fill(self, context, queue):
+    def test_fill(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         shape = (75, 63)
         template = fill.FillTemplate(context, np.uint32, 'unsigned int')
         fn = template.instantiate(queue, shape)
-        self.pad_dimension(fn.slots['data'].dimensions[0], 5)
-        self.pad_dimension(fn.slots['data'].dimensions[1], 10)
+        data_slot = cast(accel.IOSlot, fn.slots['data'])
+        self.pad_dimension(data_slot.dimensions[0], 5)
+        self.pad_dimension(data_slot.dimensions[1], 10)
         fn.ensure_all_bound()
         data = fn.buffer('data')
         # Do the fill
@@ -31,6 +35,6 @@ class TestFill(object):
 
     @device_test
     @force_autotune
-    def test_autotune(self, context, queue):
+    def test_autotune(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         """Test that autotuner runs successfully"""
         fill.FillTemplate(context, np.uint8, 'unsigned char')

--- a/katsdpsigproc/test/test_maskedsum.py
+++ b/katsdpsigproc/test/test_maskedsum.py
@@ -1,12 +1,17 @@
+from typing import Tuple, Generator, Callable, cast
+
 import numpy as np
 
 from .test_accel import device_test, force_autotune
 from .. import accel
 from .. import maskedsum
+from ..abc import AbstractContext, AbstractCommandQueue
 
 
-class TestMaskedSum(object):
-    def test_maskedsum(self):
+class TestMaskedSum:
+    def test_maskedsum(self) -> Generator[
+            Tuple[Callable[[int, int, bool], None], int, int, bool],
+            None, None]:
         for use_amplitudes in (False, True):
             yield self.check_maskedsum, 4096, 2, use_amplitudes
             yield self.check_maskedsum, 4096, 4029, use_amplitudes
@@ -15,18 +20,20 @@ class TestMaskedSum(object):
             yield self.check_maskedsum, 4096, 4032, use_amplitudes
 
     @classmethod
-    def pad_dimension(cls, dim, extra):
+    def pad_dimension(cls, dim: accel.Dimension, extra: int) -> None:
         """Modifies `dim` to have at least `extra` padding"""
         newdim = accel.Dimension(dim.size, min_padded_size=dim.size + extra)
         newdim.link(dim)
 
     @device_test
-    def check_maskedsum(self, R, C, use_amplitudes, context, queue):
+    def check_maskedsum(self, R: int, C: int, use_amplitudes: bool,
+                        context: AbstractContext, queue: AbstractCommandQueue) -> None:
         template = maskedsum.MaskedSumTemplate(context, use_amplitudes)
         fn = template.instantiate(queue, (R, C))
         # Force some padding, to check that stride calculation works
-        self.pad_dimension(fn.slots['src'].dimensions[0], 1)
-        self.pad_dimension(fn.slots['src'].dimensions[1], 4)
+        src_slot = cast(accel.IOSlot, fn.slots['src'])
+        self.pad_dimension(src_slot.dimensions[0], 1)
+        self.pad_dimension(src_slot.dimensions[1], 4)
         ary = np.random.randn(R, C, 2).astype(np.float32).view(dtype=np.complex64)[..., 0]
         msk = np.ones((R,)).astype(np.float32)
         src = fn.slots['src'].allocate(fn.allocator)
@@ -45,7 +52,7 @@ class TestMaskedSum(object):
 
     @device_test
     @force_autotune
-    def test_autotune(self, context, queue):
+    def test_autotune(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         """Check that the autotuner runs successfully"""
         maskedsum.MaskedSumTemplate(context, False)
         maskedsum.MaskedSumTemplate(context, True)

--- a/katsdpsigproc/test/test_transpose.py
+++ b/katsdpsigproc/test/test_transpose.py
@@ -1,32 +1,38 @@
-from __future__ import division, print_function, absolute_import
+from typing import Tuple, Callable, Generator, cast
+
 import numpy as np
+
 from .test_accel import device_test, force_autotune
 from .. import accel
 from .. import transpose
+from ..abc import AbstractContext, AbstractCommandQueue
 
 
-class TestTranspose(object):
-    def test_transpose(self):
+class TestTranspose:
+    def test_transpose(self) -> Generator[Tuple[Callable[[int, int], None], int, int], None, None]:
         yield self.check_transpose, 4, 5
         yield self.check_transpose, 53, 7
         yield self.check_transpose, 53, 81
         yield self.check_transpose, 32, 64
 
     @classmethod
-    def pad_dimension(cls, dim, extra):
+    def pad_dimension(cls, dim: accel.Dimension, extra: int) -> None:
         """Modifies `dim` to have at least `extra` padding"""
         newdim = accel.Dimension(dim.size, min_padded_size=dim.size + extra)
         newdim.link(dim)
 
     @device_test
-    def check_transpose(self, R, C, context, queue):
+    def check_transpose(self, R: int, C: int,
+                        context: AbstractContext, queue: AbstractCommandQueue) -> None:
         template = transpose.TransposeTemplate(context, np.float32, 'float')
         fn = template.instantiate(queue, (R, C))
         # Force some padded, to check that stride calculation works
-        self.pad_dimension(fn.slots['src'].dimensions[0], 1)
-        self.pad_dimension(fn.slots['src'].dimensions[1], 4)
-        self.pad_dimension(fn.slots['dest'].dimensions[0], 2)
-        self.pad_dimension(fn.slots['dest'].dimensions[1], 3)
+        src_slot = cast(accel.IOSlot, fn.slots['src'])
+        dest_slot = cast(accel.IOSlot, fn.slots['dest'])
+        self.pad_dimension(src_slot.dimensions[0], 1)
+        self.pad_dimension(src_slot.dimensions[1], 4)
+        self.pad_dimension(dest_slot.dimensions[0], 2)
+        self.pad_dimension(dest_slot.dimensions[1], 3)
 
         ary = np.random.randn(R, C).astype(np.float32)
         src = fn.slots['src'].allocate(fn.allocator)
@@ -38,6 +44,6 @@ class TestTranspose(object):
 
     @device_test
     @force_autotune
-    def test_autotune(self, context, queue):
+    def test_autotune(self, context: AbstractContext, queue: AbstractCommandQueue) -> None:
         """Check that the autotuner runs successfully"""
         transpose.TransposeTemplate(context, np.uint8, 'unsigned char')

--- a/katsdpsigproc/tune.py
+++ b/katsdpsigproc/tune.py
@@ -80,12 +80,12 @@ def _db_keys(fn: _TuningFunc, args: Sequence, kwargs: Mapping) -> Dict[str, Any]
 
        :func:`autotuner`
     """
-    argspec = inspect.getargspec(fn)
     # Extract the arguments passed to the wrapped function, by name
-    named_args = dict(kwargs)
-    for i in range(2, len(args)):
-        named_args[argspec.args[i]] = args[i]
-    keys = dict([('arg_' + key, adapt_value(value)) for (key, value) in named_args.items()])
+    sig = inspect.signature(fn)
+    bound = sig.bind(*args, **kwargs)
+    bound.apply_defaults()
+    keys = {'arg_' + name: adapt_value(value)
+            for (name, value) in itertools.islice(bound.arguments.items(), 2, None)}
 
     # Add information about the device
     device = args[1].device

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="MeerKAT SDP team",
     author_email="sdpdev+katsdpsigproc@ska.ac.za",
     packages=find_packages(),
-    package_data={'': ['*.mako']},
+    package_data={'': ['*.mako'], 'katsdpsigproc': ['py.typed']},
     url="https://github.com/ska-sa/katsdpsigproc",
     setup_requires=["katversion"],
     install_requires=[


### PR DESCRIPTION
This adds type annotations to the rest of katsdpsigproc.test. I think
this should cover everything outside of katsdpsigproc.rfi and maybe the
scripts.

There are a few related changes:
- The autotuner now uses inspect.signature instead of the deprecated
  inspect.getargspec to introspect the arguments.
- The file py.typed is added to tell mypy that katsdpsigproc has inline
  annotations (so that it uses them when checking *other* packages).