### PR TITLE
Fix test_accel when pyopencl not installed

### DIFF
--- a/katsdpsigproc/test/test_accel.py
+++ b/katsdpsigproc/test/test_accel.py
@@ -15,12 +15,13 @@ from mako.template import Template
 from nose.tools import assert_equal, assert_raises
 from nose.plugins.skip import SkipTest
 
-from .. import accel, tune, opencl
+from .. import accel, tune
 from ..accel import HostArray, DeviceArray, SVMArray, LinenoLexer
 from ..abc import AbstractContext, AbstractCommandQueue
 if accel.have_cuda:
     import pycuda
 if accel.have_opencl:
+    from .. import opencl
     import pyopencl
 
 


### PR DESCRIPTION
The import of opencl needed to be made conditional.