### PR TITLE
Use BLOCKING_SYNC for events

### DIFF
--- a/katsdpsigproc/cuda.py
+++ b/katsdpsigproc/cuda.py
@@ -357,7 +357,7 @@ class CommandQueue(AbstractCommandQueue[pycuda.gpuarray.GPUArray, Context, Event
 
     def enqueue_marker(self) -> Event:
         with self.context:
-            event = pycuda.driver.Event()
+            event = pycuda.driver.Event(pycuda.driver.event_flags.BLOCKING_SYNC)
             event.record(self._pycuda_stream)
         return Event(event)
 


### PR DESCRIPTION
This makes waiting for events interrupt-driven rather than spinning on
the CPU. In most cases users of katsdpsigproc have other work to do (or
other processes making use of CPU) so this is friendlier. It will
increase latency fractionally, but I don't think it's typically being
used with tiny kernels so I'm not worried.