### PR TITLE
Update requirements to match katsdpdockerbase update

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -15,7 +15,13 @@ requests
 six
 snowballstemmer
 sphinx
+sphinxcontrib-applehelp
 sphinxcontrib-asyncio==0.2.0
+sphinxcontrib-devhelp
+sphinxcontrib-htmlhelp
+sphinxcontrib-jsmath
+sphinxcontrib-qthelp
+sphinxcontrib-serializinghtml
 sphinxcontrib-websupport
 sphinx-rtd-theme
 urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,16 @@
 appdirs
-cffi
 decorator
-funcsigs                   # Needed by numba
 katversion
-llvmlite                   # Needed by numba
+llvmlite                   # via numba
 mako
-markupsafe
+markupsafe                 # via mako
 numba
 numpy
 pandas
-py
-pycparser
 pycuda
 pyopencl
-pytest
-python-dateutil            # Needed by Pandas
+python-dateutil            # via Pandas
 pytools
-pytz                       # Needed by Pandas
+pytz                       # via Pandas
 scipy
 typing_extensions


### PR DESCRIPTION
This should be merged together with ska-sa/katsdpdockerbase#46. It may
currently fail to build until that branch is merged.