### PR TITLE
Make zscale return nans when the input sample array is empty

### DIFF
--- a/katsdpsigproc/test/test_zscale.py
+++ b/katsdpsigproc/test/test_zscale.py
@@ -25,6 +25,11 @@ class TestSampleImage:
         sample = sample_image(self.image, 10000)
         np.testing.assert_array_equal(sample, np.arange(1.0, 30.0))
 
+    def test_all_nan(self):
+        self.image[:] = np.nan
+        sample = sample_image(self.image, 10000)
+        assert_equal(sample.size, 0)
+
     def test_random_offsets(self):
         image = np.arange(10000.0).reshape(100, 100)
         rs = np.random.RandomState(seed=1)
@@ -69,3 +74,8 @@ class TestZscale:
         z1, z2 = zscale(self.samples, contrast=0.2, stretch=2.0)
         np.testing.assert_allclose(z1, 5.5 - 1.5 / 0.2 / 2, rtol=1e-1)
         np.testing.assert_allclose(z2, 5.5 + 1.5 / 0.2 * 2, rtol=1e-1)
+
+    def test_empty_samples(self):
+        z1, z2 = zscale([])
+        np.testing.assert_equal(z1, np.nan)
+        np.testing.assert_equal(z2, np.nan)

--- a/katsdpsigproc/zscale.py
+++ b/katsdpsigproc/zscale.py
@@ -101,7 +101,7 @@ def zscale(samples: np.ndarray, *, contrast: float = 0.02, stretch: float = 5.0,
     -------
     z1, z2 : float
         Minimum and maximum sample values to be mapped to the extremes
-        of a colour map.
+        of a colour map. These will be nans if samples is empty.
     """
     samples = np.sort(samples)
     npix = len(samples)

--- a/katsdpsigproc/zscale.py
+++ b/katsdpsigproc/zscale.py
@@ -105,6 +105,9 @@ def zscale(samples: np.ndarray, *, contrast: float = 0.02, stretch: float = 5.0,
     """
     samples = np.sort(samples)
     npix = len(samples)
+    # Return nans if samples is empty
+    if npix == 0:
+        return np.nan, np.nan
     zmin = samples[0]
     zmax = samples[-1]
 


### PR DESCRIPTION
This is most likely to occur when the input image is completely non-finite. Returning nans will work for the vmin, vmax parameters of pyplot.imshow, in which case the scaling is just set to some default and allows completely blanked FITS images to be displayed when scaled using zscale.