### PR TITLE
Move some flake8 F811 annotations

### DIFF
--- a/katsdpsigproc/accel.py
+++ b/katsdpsigproc/accel.py
@@ -365,13 +365,13 @@ class HostArray(np.ndarray):
     def padded_view(cls, obj: 'HostArray') -> np.ndarray:
         ...
 
-    @overload       # noqa: F811
+    @overload
     @classmethod
-    def padded_view(cls, obj: np.ndarray) -> Optional[np.ndarray]:
+    def padded_view(cls, obj: np.ndarray) -> Optional[np.ndarray]:    # noqa: F811
         ...
 
-    @classmethod    # noqa: F811
-    def padded_view(cls, obj: np.ndarray) -> Optional[np.ndarray]:
+    @classmethod
+    def padded_view(cls, obj: np.ndarray) -> Optional[np.ndarray]:    # noqa: F811
         """Retrieve the view of the full memory without padding.
 
         Returns `None` if `cls.safe(obj)` is `False`.


### PR DESCRIPTION
Something about the recent upgrades (possibly to 3.8) caused flake8 to
start expecting the noqa annotations on a different line.

It looks like the latest flake8 no longer needs the annotations
(presumably it now understands `@overload`) but I don't feel like
upgrading things at this point.