### PR TITLE
Add pytest plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,5 @@ repos:
         pass_filenames: false
         additional_dependencies: [
           "numpy==1.21.1",
+          "pytest==6.2.5"
         ]

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2019, National Research Foundation (SARAO)
+Copyright (c) 2014-2021, National Research Foundation (SARAO)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/doc/katsdpsigproc.asyncio.rst
+++ b/doc/katsdpsigproc.asyncio.rst
@@ -12,7 +12,6 @@ katsdpsigproc.asyncio.resource module
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/doc/katsdpsigproc.rfi.rst
+++ b/doc/katsdpsigproc.rfi.rst
@@ -5,6 +5,7 @@ Subpackages
 -----------
 
 .. toctree::
+   :maxdepth: 4
 
    katsdpsigproc.rfi.test
 
@@ -34,7 +35,6 @@ katsdpsigproc.rfi.twodflag module
    :members:
    :undoc-members:
    :show-inheritance:
-
 
 Module contents
 ---------------

--- a/doc/katsdpsigproc.rfi.test.rst
+++ b/doc/katsdpsigproc.rfi.test.rst
@@ -44,7 +44,6 @@ katsdpsigproc.rfi.test.test\_twodflag module
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/doc/katsdpsigproc.rst
+++ b/doc/katsdpsigproc.rst
@@ -5,6 +5,7 @@ Subpackages
 -----------
 
 .. toctree::
+   :maxdepth: 4
 
    katsdpsigproc.asyncio
    katsdpsigproc.rfi
@@ -69,6 +70,14 @@ katsdpsigproc.percentile module
    :undoc-members:
    :show-inheritance:
 
+katsdpsigproc.pytest\_plugin module
+-----------------------------------
+
+.. automodule:: katsdpsigproc.pytest_plugin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 katsdpsigproc.reduce module
 ---------------------------
 
@@ -100,7 +109,6 @@ katsdpsigproc.tune module
    :members:
    :undoc-members:
    :show-inheritance:
-
 
 Module contents
 ---------------

--- a/doc/katsdpsigproc.test.rst
+++ b/doc/katsdpsigproc.test.rst
@@ -76,7 +76,6 @@ katsdpsigproc.test.test\_tune module
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/doc/user/testing.rst
+++ b/doc/user/testing.rst
@@ -1,14 +1,17 @@
 Testing
 =======
 Testing GPU code requires a little more setup than regular code. At a minimum
-you will normally need a context and a command queue. The
-:mod:`katsdpsigproc.test.test_accel` module provides a number of decorators
+you will normally need a context and a command queue. There are two modules
+that provide support for testing, depending on which testing framework is in
+use.
+
+nose
+----
+The :mod:`katsdpsigproc.test.test_accel` module provides a number of decorators
 that can be used to simplify writing test functions. They are designed for use
-with `nose`_. You might be able to make them work with `pytest`_ too, but
-there is no specific pytest support yet.
+with `nose`_.
 
 .. _nose: https://nose.readthedocs.io
-.. _pytest: https://docs.pytest.org
 
 To write a test function, give it two extra arguments, which will be the
 context and command queue (you can call them anything as they are passed
@@ -19,15 +22,15 @@ previous sections.
 .. code:: python
 
     @device_test
-    def test_multiply(ctx, queue):
+    def test_multiply(context, command_queue):
         size = 53
-        template = MultiplyTemplate(ctx)
-        op = template.instantiate(queue, size, 4.0)
+        template = MultiplyTemplate(context)
+        op = template.instantiate(command_queue, size, 4.0)
         op.ensure_all_bound()
         src = np.random.uniform(size=size).astype(np.float32)
-        op.buffer('data').set(queue, src)
+        op.buffer('data').set(command_queue, src)
         op()
-        dst = op.buffer('data').get(queue)
+        dst = op.buffer('data').get(command_queue)
         np.testing.assert_array_equal(dst, src * 4.0)
 
 The device and command queue are created the first time one of the decorated
@@ -42,3 +45,110 @@ used.
 
 See also :ref:`Testing autotuning <autotune-testing>` for information about how
 testing interacts with autotuning.
+
+.. _testing-pytest:
+
+pytest
+------
+The module :mod:`katsdpsigproc.pytest_plugin` provides a pytest plugin to
+simplify writing tests. It is not enabled by default, because the fixture names
+and markers that it defines are very generic and may conflict with other
+plugins. To enable it, add the following to your top-level ``conftest.py``:
+
+.. code:: python
+
+   pytest_plugins = ["katsdpsigproc.pytest_plugin"]
+
+.. _pytest-device-selection:
+
+Device selection
+^^^^^^^^^^^^^^^^
+There is a low-level fixture called ``device``, although you will probably not
+need to use it directly. It is parametrized, allowing tests to be repeated on
+multiple devices. The devices to use can be controlled by passing
+:option:`!--devices` on the pytest command line. The possible values are
+
+``first-per-api`` (default)
+    Use the first available CUDA device (if any) and the first available
+    OpenCL device (if any).
+
+``all``
+    Use all available devices.
+
+``none``
+    Skip tests that depend on the ``device`` fixture.
+
+The environment variables that control device selection in
+:func:`~.create_some_context` can also be used here to pick a specific
+device. Tests can also use marks (see below) to filter out devices that are
+not suitable for the test.
+
+If no suitable devices are available, the test is marked as ``xfail`` and not
+run.
+
+Fixtures
+^^^^^^^^
+.. _fixture-patch_autotune:
+
+patch_autotune
+    Disable the normal autotuning, instead using the `test` parameter to
+    :func:`.tune.autotuner` as the result of autotuning. This behaviour can
+    be overridden with the :ref:`force_autotune <mark-force_autotune>` mark.
+
+.. _fixture-device:
+
+device (:class:`~.AbstractDevice`)
+    See :ref:`pytest-device-selection`.
+
+.. _fixture-context:
+
+context (:class:`~.AbstractContext`)
+    A context created from :ref:`device <pytest-device-selection>`. It
+    automatically depends on :ref:`patch_autotune <fixture-patch_autotune>`.
+    For CUDA, the context is also made current for the duration of the test.
+
+command_queue (:class:`~.AbstractCommandQueue`)
+    A command queue created from :ref:`context <fixture-context>`.
+
+Marks
+^^^^^
+cuda_only
+    Restrict device selection to CUDA devices. An optional
+    `min_compute_capability` keyword argument can be set to a 2-tuple of
+    integers to set a minimum CUDA compute capability e.g. ``(7, 2)`` will
+    limit device selection to devices of compute capability 7.2 or higher.
+
+opencl_only
+    Restrict device selection to OpenCL devices.
+
+device_filter(filter)
+    Provide an arbitrary predicate which decides whether a device should be
+    considered or not.
+
+.. _mark-force_autotune:
+
+force_autotune
+    When combined with the :ref:`patch_autotune <fixture-patch_autotune>`
+    fixture (usually implicitly, as it is used by the :ref:`context
+    <fixture-context>` fixture), run the full autotuning unconditionally
+    (ignoring any results in the autotuning database).
+
+Example
+^^^^^^^
+The example is almost identical to that for nose, but without the need for a
+decorator:
+
+.. code:: python
+
+    pytest_plugins = ["katsdpsigproc.pytest_plugin"]
+
+    def test_multiply(context, command_queue):
+        size = 53
+        template = MultiplyTemplate(context)
+        op = template.instantiate(command_queue, size, 4.0)
+        op.ensure_all_bound()
+        src = np.random.uniform(size=size).astype(np.float32)
+        op.buffer('data').set(command_queue, src)
+        op()
+        dst = op.buffer('data').get(command_queue)
+        np.testing.assert_array_equal(dst, src * 4.0)

--- a/doc/user/testing.rst
+++ b/doc/user/testing.rst
@@ -123,7 +123,10 @@ opencl_only
 
 device_filter(filter)
     Provide an arbitrary predicate which decides whether a device should be
-    considered or not.
+    considered or not. Note that this needs to be invoked as
+    ``pytest.mark.device_filter.with_args(filter)`` to make pytest aware
+    that the filter is an argument to the mark rather than a function to
+    decorate with the mark.
 
 .. _mark-force_autotune:
 

--- a/katsdpsigproc/cuda.py
+++ b/katsdpsigproc/cuda.py
@@ -100,6 +100,10 @@ class Device(AbstractDevice['Context']):
     def simd_group_size(self) -> int:
         return self._pycuda_device.warp_size
 
+    @property
+    def compute_capability(self) -> Tuple[int, int]:
+        return self._pycuda_device.compute_capability()
+
     @classmethod
     def get_devices(cls: Type[_D]) -> Sequence[_D]:
         num_devices = pycuda.driver.Device.count()

--- a/katsdpsigproc/pytest_plugin.py
+++ b/katsdpsigproc/pytest_plugin.py
@@ -1,0 +1,113 @@
+"""Plugin for testing with pytest.
+
+See the :ref:`testing-pytest` section of the documentation for details.
+"""
+
+import itertools
+from typing import Generator
+
+import pytest
+
+from . import abc, accel, tune
+
+
+_devices = accel.all_devices()
+
+
+@pytest.fixture
+def patch_autotune(request, monkeypatch) -> None:
+    autotuner = tune.stub_autotuner
+    if request.node.get_closest_marker("force_autotune"):
+        autotuner = tune.force_autotuner
+    monkeypatch.setattr(tune, "autotuner_impl", autotuner)
+
+
+@pytest.fixture
+def context(device: abc.AbstractDevice,
+            patch_autotune) -> Generator[abc.AbstractContext, None, None]:
+    # Make the context current (for CUDA contexts). Ideally the test
+    # should not depend on this, but PyCUDA leaks memory if objects
+    # are deleted without the context current.
+    with device.make_context() as context:
+        yield context
+
+
+@pytest.fixture
+def command_queue(context: abc.AbstractContext) -> abc.AbstractCommandQueue:
+    return context.create_command_queue()
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("katsdpsigproc")
+    group.addoption(
+        "--devices",
+        choices=["first-per-api", "all", "none"],
+        default="first-per-api",
+        help="Select which devices to use for testing"
+    )
+
+
+def pytest_configure(config) -> None:
+    config.addinivalue_line("markers", "force_autotune: unconditionally run autotuning")
+    config.addinivalue_line("markers", "cuda_only: run test only on CUDA devices")
+    config.addinivalue_line("markers", "opencl_only: run test only on OpenCL devices")
+    config.addinivalue_line(
+        "markers", "device_filter(filter): run test only on devices matching 'filter'")
+
+
+def pytest_generate_tests(metafunc) -> None:
+    if "device" in metafunc.fixturenames:
+        option = metafunc.config.getoption("devices")
+        if option == "none":
+            metafunc.parametrize(
+                "device",
+                [
+                    pytest.param(
+                        None, marks=pytest.mark.skip(reason="--devices=none passed on command line")
+                    )
+                ]
+            )
+            return
+
+        devices = accel.candidate_devices()
+        # Apply filters. This is done after calling candidate_devices rather
+        # than by passing a device filter, so that
+        # environment variables like KATSDPSIGPROC_DEVICE are interpreted
+        # relative to the full device list rather than a filtered list, which
+        # could cause tests with different filters to select different
+        # devices.
+        for marker in metafunc.definition.iter_markers("cuda_only"):
+            min_cc = marker.kwargs.get("min_compute_capability", (0, 0))
+            devices = [
+                device
+                for device in devices
+                if device.is_cuda and device.compute_capability >= min_cc]  # type: ignore
+        if metafunc.definition.get_closest_marker("opencl_only") is not None:
+            devices = [device for device in devices if not device.is_cuda]
+        for marker in metafunc.definition.iter_markers("device_filter"):
+            devices = [device for device in devices if marker.args[0](device)]
+
+        # Apply --devices command-line setting
+        if option == "first-per-api":
+            # Sort so that itertools.groupby finds all devices from the same
+            # API together.
+            def classify_api(device: abc.AbstractDevice) -> bool:
+                return device.is_cuda  # Currently only 2 APIs, so this is sufficient
+
+            devices = sorted(devices, key=classify_api)
+            # group is an iterable, so next(group) gives the first element
+            devices = [next(group) for _, group in itertools.groupby(devices, key=classify_api)]
+        # Nothing needed for --devices=all, and --devices=none handled earlier
+
+        ids = [f"{d.name} ({d.platform_name})" for d in devices]
+        if not devices:
+            metafunc.parametrize(
+                "device",
+                [
+                    pytest.param(
+                        None, marks=pytest.mark.xfail(reason="No matching device found", run=False)
+                    )
+                ]
+            )
+        else:
+            metafunc.parametrize("device", devices, ids=ids)

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,5 +2,5 @@
 python_version = 3.6
 files = katsdpsigproc, scripts, doc/user/examples
 
-[mypy-appdirs.*,asynctest.*,graphviz.*,katversion.*,mako.*,numba.*,nose.*,pandas.*,pycuda.*,pyopencl.*,scipy.*]
+[mypy-appdirs.*,asynctest.*,graphviz.*,katversion.*,mako.*,numba.*,nose.*,pandas.*,pycuda.*,pyopencl.*,pytest.*,scipy.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,5 +2,5 @@
 python_version = 3.6
 files = katsdpsigproc, scripts, doc/user/examples
 
-[mypy-appdirs.*,asynctest.*,graphviz.*,katversion.*,mako.*,numba.*,nose.*,pandas.*,pycuda.*,pyopencl.*,pytest.*,scipy.*]
+[mypy-appdirs.*,asynctest.*,graphviz.*,katversion.*,mako.*,numba.*,nose.*,pandas.*,pycuda.*,pyopencl.*,scipy.*]
 ignore_missing_imports = True

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ asynctest
 coverage
 graphviz==0.12
 nose
+pytest  # Not used for unit tests, but mypy needs it to check pytest_plugin


### PR DESCRIPTION
This brings equivalent capabilities (and more) to using katsdpsigproc
with pytest as katsdpsigproc.test.test_accel does for nose. It does not
itself have any tests, as this would require switching katsdpsigproc
itself from nose to pytest.

Relates to NGC-272.