### PR TITLE
Add FFT based on cuFFT

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,6 @@ repos:
         args: []
         pass_filenames: false
         additional_dependencies: [
-          "numpy==1.21.1",
+          "numpy==1.20.1",
           "pytest==6.2.5"
         ]

--- a/doc/katsdpsigproc.rst
+++ b/doc/katsdpsigproc.rst
@@ -38,6 +38,14 @@ katsdpsigproc.cuda module
    :undoc-members:
    :show-inheritance:
 
+katsdpsigproc.fft module
+------------------------
+
+.. automodule:: katsdpsigproc.fft
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 katsdpsigproc.fill module
 -------------------------
 

--- a/doc/katsdpsigproc.test.rst
+++ b/doc/katsdpsigproc.test.rst
@@ -12,6 +12,14 @@ katsdpsigproc.test.test\_accel module
    :undoc-members:
    :show-inheritance:
 
+katsdpsigproc.test.test\_fft module
+-----------------------------------
+
+.. automodule:: katsdpsigproc.test.test_fft
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 katsdpsigproc.test.test\_fill module
 ------------------------------------
 

--- a/katsdpsigproc/fft.py
+++ b/katsdpsigproc/fft.py
@@ -1,0 +1,190 @@
+"""Fast Fourier Transforms.
+
+Currently this module only supports CUDA, using CUFFT.
+"""
+
+from enum import Enum
+import threading
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+try:
+    from numpy.typing import DTypeLike
+except ImportError:
+    DTypeLike = Any  # type: ignore
+import skcuda.fft
+
+from . import accel, cuda
+from .accel import AbstractAllocator
+from .abc import AbstractContext, AbstractCommandQueue
+
+
+class FftMode(Enum):
+    FORWARD = 0
+    INVERSE = 1
+
+
+class FftTemplate:
+    r"""Operation template for a forward or reverse FFT.
+
+    The transformation is done over the last N dimensions, with the remaining
+    dimensions for batching multiple arrays to be transformed. Dimensions
+    before the first N must not be padded.
+
+    This template bakes in more information than most (data shapes), which is
+    due to constraints in CUFFT.
+
+    The template can specify real->complex, complex->real, or
+    complex->complex. In the last case, the same template can be used to
+    instantiate forward or inverse transforms. Otherwise, real->complex
+    transforms must be forward, and complex->real transforms must be inverse.
+
+    For real<->complex transforms, the final dimension of the padded shape
+    need only be :math:`\lfloor\frac{L}{2}\rfloor + 1`, where :math:`L` is the
+    last element of `shape`.
+
+    Parameters
+    ----------
+    context
+        Context for the operation
+    N
+        Number of dimensions for the transform
+    shape
+        Shape of the input (N or more dimensions)
+    dtype_src : {`np.float32`, `np.float64`, `np.complex64`, `np.complex128`}
+        Data type for input
+    dtype_dest : {`np.float32`, `np.float64`, `np.complex64`, `np.complex128`}
+        Data type for output
+    padded_shape_src
+        Padded shape of the input
+    padded_shape_dest
+        Padded shape of the output
+    tuning
+        Tuning parameters (currently unused)
+    """
+
+    def __init__(
+        self,
+        context: AbstractContext,
+        N: int,
+        shape: Tuple[int, ...],
+        dtype_src: DTypeLike,
+        dtype_dest: DTypeLike,
+        padded_shape_src: Tuple[int, ...],
+        padded_shape_dest: Tuple[int, ...],
+        tuning: Optional[Dict[str, Any]] = None
+    ) -> None:
+        if not isinstance(context, cuda.Context):
+            raise TypeError('Only CUDA contexts are supported')
+        if len(padded_shape_src) != len(shape):
+            raise ValueError('padded_shape_src and shape must have same length')
+        if len(padded_shape_dest) != len(shape):
+            raise ValueError('padded_shape_dest and shape must have same length')
+        if padded_shape_src[:-N] != shape[:-N]:
+            raise ValueError('Source must not be padded on batch dimensions')
+        if padded_shape_dest[:-N] != shape[:-N]:
+            raise ValueError('Destination must not be padded on batch dimensions')
+        self.context: cuda.Context = context
+        self.shape = shape
+        self.dtype_src = np.dtype(dtype_src)
+        self.dtype_dest = np.dtype(dtype_dest)
+        self.padded_shape_src = padded_shape_src
+        self.padded_shape_dest = padded_shape_dest
+        # CUDA 7.0 CUFFT has a bug where kernels are run in the default stream
+        # instead of the requested one, if dimensions are up to 1920. There is
+        # a patch, but there is no query to detect whether it has been
+        # applied.
+        self._needs_synchronize_workaround = (
+            skcuda.cufft.cufftGetVersion() < 8000 and any(x <= 1920 for x in shape[:N])
+        )
+        batches = int(np.product(padded_shape_src[:-N]))
+        with context:
+            self.plan = skcuda.fft.Plan(
+                shape[-N:], dtype_src, dtype_dest, batches,
+                inembed=np.array(padded_shape_src[-N:], np.int32),
+                istride=1,
+                idist=int(np.product(padded_shape_src[-N:])),
+                onembed=np.array(padded_shape_dest[-N:], np.int32),
+                ostride=1,
+                odist=int(np.product(padded_shape_dest[-N:])),
+                auto_allocate=False)
+        # The stream and work area are associated with the plan rather than
+        # the execution, so we need to serialise executions.
+        self.lock = threading.RLock()
+
+    def instantiate(self, *args, **kwargs):
+        return Fft(self, *args, **kwargs)
+
+
+class Fft(accel.Operation):
+    """Forward or inverse Fourier transformation.
+
+    .. rubric:: Slots
+
+    **src**
+        Input data
+    **dest**
+        Output data
+    **work_area**
+        Scratch area for work. The contents should not be used; it is made
+        available so that it can be aliased with other scratch areas.
+
+    Parameters
+    ----------
+    template
+        Operation template
+    command_queue
+        Command queue for the operation
+    mode
+        FFT direction
+    allocator
+        Allocator used to allocate unbound slots
+    """
+
+    command_queue: cuda.CommandQueue  # refine the type for mypy
+
+    def __init__(
+        self,
+        template: FftTemplate,
+        command_queue: AbstractCommandQueue,
+        mode: FftMode,
+        allocator: Optional[AbstractAllocator] = None
+    ) -> None:
+        if not isinstance(command_queue, cuda.CommandQueue):
+            raise TypeError('Only CUDA command queues are supported')
+        super().__init__(command_queue, allocator)
+        self.template = template
+        src_shape = list(template.shape)
+        dest_shape = list(template.shape)
+        if template.dtype_src.kind != 'c':
+            if mode != FftMode.FORWARD:
+                raise ValueError('R2C transform must use FftMode.FORWARD')
+            dest_shape[-1] = template.shape[-1] // 2 + 1
+        if template.dtype_dest.kind != 'c':
+            if mode != FftMode.INVERSE:
+                raise ValueError('C2R transform must use FftMode.INVERSE')
+            src_shape[-1] = template.shape[-1] // 2 + 1
+        src_dims = tuple(accel.Dimension(d[0], min_padded_size=d[1], exact=True)
+                         for d in zip(src_shape, template.padded_shape_src))
+        dest_dims = tuple(accel.Dimension(d[0], min_padded_size=d[1], exact=True)
+                          for d in zip(dest_shape, template.padded_shape_dest))
+        self.slots['src'] = accel.IOSlot(src_dims, template.dtype_src)
+        self.slots['dest'] = accel.IOSlot(dest_dims, template.dtype_dest)
+        self.slots['work_area'] = accel.IOSlot((template.plan.worksize,), np.uint8)
+        self.mode = mode
+
+    def _run(self) -> None:
+        src_buffer = self.buffer('src')
+        dest_buffer = self.buffer('dest')
+        work_area_buffer = self.buffer('work_area')
+        context = self.command_queue.context
+        with context, self.template.lock:
+            skcuda.cufft.cufftSetStream(self.template.plan.handle,
+                                        self.command_queue._pycuda_stream.handle)
+            self.template.plan.set_work_area(work_area_buffer.buffer)
+            if self.mode == FftMode.FORWARD:
+                skcuda.fft.fft(src_buffer.buffer, dest_buffer.buffer, self.template.plan)
+            else:
+                skcuda.fft.ifft(src_buffer.buffer, dest_buffer.buffer, self.template.plan)
+            if self.template._needs_synchronize_workaround:
+                context._pycuda_context.synchronize()

--- a/katsdpsigproc/fft.py
+++ b/katsdpsigproc/fft.py
@@ -193,6 +193,9 @@ class FftTemplate:
     need only be :math:`\lfloor\frac{L}{2}\rfloor + 1`, where :math:`L` is the
     last element of `shape`.
 
+    The transform is unnormalised: performing a forward followed by a reverse
+    transform will scale the result by the number of elements.
+
     Parameters
     ----------
     context

--- a/katsdpsigproc/fft.py
+++ b/katsdpsigproc/fft.py
@@ -258,8 +258,10 @@ class FftTemplate:
         cufft = _Cufft()
         self.context: cuda.Context = context
         self.shape = shape
-        self.dtype_src = np.dtype(dtype_src)
-        self.dtype_dest = np.dtype(dtype_dest)
+        # TODO: the type annotation is necessary with numpy 1.20.1, but
+        # is no longer needed for newer versions.
+        self.dtype_src: np.dtype = np.dtype(dtype_src)
+        self.dtype_dest: np.dtype = np.dtype(dtype_dest)
         self.padded_shape_src = padded_shape_src
         self.padded_shape_dest = padded_shape_dest
         # CUDA 7.0 CUFFT has a bug where kernels are run in the default stream

--- a/katsdpsigproc/rfi/test/test_background.py
+++ b/katsdpsigproc/rfi/test/test_background.py
@@ -7,6 +7,7 @@ import numpy as np
 from .. import host
 from ...abc import AbstractContext, AbstractCommandQueue
 from ...test.test_accel import device_test, force_autotune
+from ...test import complex_normal
 from .. import device
 
 
@@ -23,7 +24,7 @@ def setup():   # type: () -> None
     _flags = np.array([0, 0, 1, 0, 0, 4]).T.astype(np.uint8)
     # Use a fixed seed to make the test repeatable
     rs = np.random.RandomState(seed=1)
-    _vis_big = (rs.standard_normal(shape) + rs.standard_normal(shape) * 1j).astype(np.complex64)
+    _vis_big = complex_normal(rs, size=shape).astype(np.complex64)
     _flags_big = (rs.random_sample(shape) < 0.1).astype(np.uint8)
     # Ensure that in some cases the entire window is flagged. Also test with non-0/1
     # flag values.

--- a/katsdpsigproc/rfi/test/test_flagger.py
+++ b/katsdpsigproc/rfi/test/test_flagger.py
@@ -9,6 +9,7 @@ import numpy as np
 from .. import host
 from ...abc import AbstractContext, AbstractCommandQueue
 from ...test.test_accel import device_test
+from ...test import complex_normal
 from .. import device
 
 
@@ -22,7 +23,7 @@ def setup():   # type: () -> None
     shape = (117, 131)
     # Use a fixed seed to make the test repeatable
     rs = np.random.RandomState(seed=1)
-    _vis = rs.standard_normal(shape) + 1j * rs.standard_normal(shape)
+    _vis = complex_normal(rs, size=shape)
     # Pick 1/16 of samples to be RFI
     # Give them random amplitude from a range, and random phase
     _spikes = rs.random_sample(shape) < 1.0 / 16.0

--- a/katsdpsigproc/test/__init__.py
+++ b/katsdpsigproc/test/__init__.py
@@ -1,1 +1,44 @@
 """Unit tests for :mod:`katsdpsigproc`."""
+
+from typing import Any, Tuple, Union
+
+import numpy as np
+try:
+    from numpy.typing import ArrayLike
+except ImportError:
+    ArrayLike = Any  # type: ignore
+
+
+_RS = Union[np.random.RandomState, np.random.Generator]
+
+
+def complex_normal(
+    state: _RS,
+    loc: ArrayLike = 0.0j,
+    scale: ArrayLike = 1.0,
+    size: Union[int, Tuple[int, ...], None] = None
+):
+    """Generate a circularly symmetric Gaussian in the Argand plane."""
+    return (
+        state.normal(np.real(loc), scale, size)         # type: ignore
+        + 1j * state.normal(np.imag(loc), scale, size)  # type: ignore
+    )
+
+
+def complex_uniform(
+    state: _RS,
+    low: ArrayLike = 0.0,
+    high: ArrayLike = 1.0,
+    size: Union[int, Tuple[int, ...], None] = None
+):
+    """Generate a uniform distribution over a rectangle in the complex plane.
+
+    If low or high is purely real (by dtype, not by value), it is taken to
+    be the boundary on both the real and imaginary extent.
+    """
+    if not np.iscomplexobj(low):
+        low = np.asarray(low) * (1 + 1j)
+    if not np.iscomplexobj(high):
+        high = np.asarray(high) * (1 + 1j)
+    return state.uniform(np.real(low), np.real(high), size) \
+        + 1j * state.uniform(np.imag(low), np.imag(high), size)

--- a/katsdpsigproc/test/__init__.py
+++ b/katsdpsigproc/test/__init__.py
@@ -23,22 +23,3 @@ def complex_normal(
         state.normal(np.real(loc), scale, size)         # type: ignore
         + 1j * state.normal(np.imag(loc), scale, size)  # type: ignore
     )
-
-
-def complex_uniform(
-    state: _RS,
-    low: ArrayLike = 0.0,
-    high: ArrayLike = 1.0,
-    size: Union[int, Tuple[int, ...], None] = None
-):
-    """Generate a uniform distribution over a rectangle in the complex plane.
-
-    If low or high is purely real (by dtype, not by value), it is taken to
-    be the boundary on both the real and imaginary extent.
-    """
-    if not np.iscomplexobj(low):
-        low = np.asarray(low) * (1 + 1j)
-    if not np.iscomplexobj(high):
-        high = np.asarray(high) * (1 + 1j)
-    return state.uniform(np.real(low), np.real(high), size) \
-        + 1j * state.uniform(np.imag(low), np.imag(high), size)

--- a/katsdpsigproc/test/test_fft.py
+++ b/katsdpsigproc/test/test_fft.py
@@ -1,0 +1,110 @@
+"""Tests for :mod:`katsdpsigproc.fft`."""
+
+from typing import Tuple
+
+import numpy as np
+
+from . import complex_normal
+from .test_accel import device_test, cuda_test
+from ..abc import AbstractContext, AbstractCommandQueue
+from .. import fft
+
+
+class TestFft:
+    @device_test
+    @cuda_test
+    def test_forward(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
+        rs = np.random.RandomState(1)
+        template = fft.FftTemplate(
+            context, 2, (3, 2, 16, 48), np.complex64, np.complex64,
+            (3, 2, 24, 64), (3, 2, 20, 48))
+        fn = template.instantiate(command_queue, fft.FftMode.FORWARD)
+        fn.ensure_all_bound()
+        src = fn.buffer('src')
+        dest = fn.buffer('dest')
+        src_host = complex_normal(rs, size=src.shape).astype(np.complex64)
+        src.set(command_queue, src_host)
+        fn()
+        expected = np.fft.fftn(src_host, axes=(2, 3))
+        np.testing.assert_allclose(expected, dest.get(command_queue), rtol=1e-4)
+
+    def _test_r2c(
+        self,
+        context: AbstractContext,
+        command_queue: AbstractCommandQueue,
+        N: int,
+        shape: Tuple[int, ...],
+        padded_shape_src: Tuple[int, ...],
+        padded_shape_dest: Tuple[int, ...]
+    ) -> None:
+        rs = np.random.RandomState(1)
+        template = fft.FftTemplate(
+            context, N, shape, np.float32, np.complex64, padded_shape_src, padded_shape_dest)
+        fn = template.instantiate(command_queue, fft.FftMode.FORWARD)
+        fn.ensure_all_bound()
+        src = fn.buffer('src')
+        dest = fn.buffer('dest')
+        src_host = rs.standard_normal(src.shape).astype(np.float32)
+        src.set(command_queue, src_host)
+        fn()
+        expected = np.fft.rfftn(src_host, axes=(2, 3))
+        np.testing.assert_allclose(expected, dest.get(command_queue), rtol=1e-4)
+
+    def _test_c2r(
+        self,
+        context: AbstractContext,
+        command_queue: AbstractCommandQueue,
+        N: int,
+        shape: Tuple[int, ...],
+        padded_shape_src: Tuple[int, ...],
+        padded_shape_dest: Tuple[int, ...]
+    ) -> None:
+        rs = np.random.RandomState(1)
+        template = fft.FftTemplate(
+            context, N, shape, np.complex64, np.float32, padded_shape_src, padded_shape_dest)
+        fn = template.instantiate(command_queue, fft.FftMode.INVERSE)
+        fn.ensure_all_bound()
+        src = fn.buffer('src')
+        dest = fn.buffer('dest')
+        signal = rs.standard_normal(shape).astype(np.float32) + 3
+        src.set(command_queue, np.fft.rfftn(signal, axes=(2, 3)).astype(np.complex64))
+        fn()
+        expected = signal * shape[2] * shape[3]
+        np.testing.assert_allclose(expected, dest.get(command_queue), rtol=1e-4)
+
+    @device_test
+    @cuda_test
+    def test_r2c_even(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
+        self._test_r2c(context, command_queue, 2, (3, 2, 16, 48), (3, 2, 24, 64), (3, 2, 20, 27))
+
+    @device_test
+    @cuda_test
+    def test_r2c_odd(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
+        self._test_r2c(context, command_queue, 2, (3, 2, 15, 47), (3, 2, 23, 63), (3, 2, 17, 24))
+
+    @device_test
+    @cuda_test
+    def test_c2r_even(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
+        self._test_c2r(context, command_queue, 2, (3, 2, 16, 48), (3, 2, 20, 27), (3, 2, 24, 64))
+
+    @device_test
+    @cuda_test
+    def test_c2r_odd(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
+        self._test_c2r(context, command_queue, 2, (3, 2, 15, 47), (3, 2, 17, 24), (3, 2, 23, 63))
+
+    @device_test
+    @cuda_test
+    def test_inverse(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
+        rs = np.random.RandomState(1)
+        template = fft.FftTemplate(
+            context, 2, (3, 2, 16, 48), np.complex64, np.complex64,
+            (3, 2, 24, 64), (3, 2, 20, 48))
+        fn = template.instantiate(command_queue, fft.FftMode.INVERSE)
+        fn.ensure_all_bound()
+        src = fn.buffer('src')
+        dest = fn.buffer('dest')
+        src_host = complex_normal(rs, size=src.shape).astype(np.complex64)
+        src.set(command_queue, src_host)
+        fn()
+        expected = np.fft.ifftn(src_host, axes=(2, 3)) * (src.shape[2] * src.shape[3])
+        np.testing.assert_allclose(expected, dest.get(command_queue), rtol=1e-4)

--- a/katsdpsigproc/test/test_fft.py
+++ b/katsdpsigproc/test/test_fft.py
@@ -1,8 +1,14 @@
 """Tests for :mod:`katsdpsigproc.fft`."""
 
-from typing import Tuple
+import ctypes
+from typing import Any, Tuple
 
 import numpy as np
+try:
+    from numpy.typing import DTypeLike
+except ImportError:
+    DTypeLike = Any  # type: ignore
+from nose.tools import assert_raises, assert_raises_regex
 
 from . import complex_normal
 from .test_accel import device_test, cuda_test
@@ -10,101 +16,247 @@ from ..abc import AbstractContext, AbstractCommandQueue
 from .. import fft
 
 
+class TestCufft:
+    """Test error handling in the :class:`._Cufft` helper class."""
+
+    def setUp(self):
+        self.cufft = fft._Cufft()
+
+    def test_invalid_plan(self):
+        plan = self.cufft.cufftHandle(123)  # An invalid plan
+        with assert_raises_regex(fft._Cufft.CufftError, "CUFFT_INVALID_PLAN"):
+            self.cufft.cufftSetAutoAllocation(plan, False)
+
+    def test_unknown_error(self):
+        with assert_raises_regex(fft._Cufft.CufftError, "cuFFT error 0x7b"):
+            raise fft._Cufft.CufftError(123)
+
+    def test_bad_cenum(self):
+        with assert_raises(ctypes.ArgumentError):
+            x = ctypes.c_longlong()
+            work_size = ctypes.c_size_t()
+            self.cufft.cufftMakePlanMany64(
+                self.cufft.cufftHandle(), x, x, x, x, x, x, x, x, "bad", x, work_size
+            )
+
+
 class TestFft:
-    @device_test
-    @cuda_test
-    def test_forward(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
+    def _test_c2c_forward(
+        self,
+        context: AbstractContext,
+        command_queue: AbstractCommandQueue,
+        shape: Tuple[int, ...],
+        dtype: DTypeLike,
+        padded_shape_src: Tuple[int, ...],
+        padded_shape_dst: Tuple[int, ...]
+    ):
         rs = np.random.RandomState(1)
         template = fft.FftTemplate(
-            context, 2, (3, 2, 16, 48), np.complex64, np.complex64,
-            (3, 2, 24, 64), (3, 2, 20, 48))
+            context, 2, shape, dtype, dtype, padded_shape_src, padded_shape_dst)
         fn = template.instantiate(command_queue, fft.FftMode.FORWARD)
         fn.ensure_all_bound()
         src = fn.buffer('src')
         dest = fn.buffer('dest')
-        src_host = complex_normal(rs, size=src.shape).astype(np.complex64)
+        src_host = complex_normal(rs, size=src.shape).astype(dtype)
         src.set(command_queue, src_host)
         fn()
-        expected = np.fft.fftn(src_host, axes=(2, 3))
-        np.testing.assert_allclose(expected, dest.get(command_queue), rtol=1e-4)
+        expected = np.fft.fftn(src_host, axes=(-2, -1))
+        tol = np.finfo(dtype).resolution * np.max(np.abs(expected))
+        np.testing.assert_allclose(expected, dest.get(command_queue), atol=tol)
+
+    def _test_c2c_inverse(
+        self,
+        context: AbstractContext,
+        command_queue: AbstractCommandQueue,
+        shape: Tuple[int, ...],
+        dtype: DTypeLike,
+        padded_shape_src: Tuple[int, ...],
+        padded_shape_dst: Tuple[int, ...]
+    ):
+        rs = np.random.RandomState(1)
+        template = fft.FftTemplate(
+            context, 2, shape, dtype, dtype, padded_shape_src, padded_shape_dst)
+        fn = template.instantiate(command_queue, fft.FftMode.INVERSE)
+        fn.ensure_all_bound()
+        src = fn.buffer('src')
+        dest = fn.buffer('dest')
+        src_host = complex_normal(rs, size=src.shape).astype(dtype)
+        src.set(command_queue, src_host)
+        fn()
+        expected = np.fft.ifftn(src_host, axes=(-2, -1)) * (src.shape[-2] * src.shape[-1])
+        tol = np.finfo(dtype).resolution * np.max(np.abs(expected))
+        np.testing.assert_allclose(expected, dest.get(command_queue), atol=tol)
 
     def _test_r2c(
         self,
         context: AbstractContext,
         command_queue: AbstractCommandQueue,
-        N: int,
         shape: Tuple[int, ...],
+        dtype_src: DTypeLike,
+        dtype_dest: DTypeLike,
         padded_shape_src: Tuple[int, ...],
         padded_shape_dest: Tuple[int, ...]
     ) -> None:
         rs = np.random.RandomState(1)
         template = fft.FftTemplate(
-            context, N, shape, np.float32, np.complex64, padded_shape_src, padded_shape_dest)
+            context, 2, shape, dtype_src, dtype_dest, padded_shape_src, padded_shape_dest)
         fn = template.instantiate(command_queue, fft.FftMode.FORWARD)
         fn.ensure_all_bound()
         src = fn.buffer('src')
         dest = fn.buffer('dest')
-        src_host = rs.standard_normal(src.shape).astype(np.float32)
+        src_host = rs.standard_normal(src.shape).astype(dtype_src)
         src.set(command_queue, src_host)
         fn()
-        expected = np.fft.rfftn(src_host, axes=(2, 3))
-        np.testing.assert_allclose(expected, dest.get(command_queue), rtol=1e-4)
+        expected = np.fft.rfftn(src_host, axes=(-2, -1))
+        tol = np.finfo(dtype_src).resolution * np.max(np.abs(expected))
+        np.testing.assert_allclose(expected, dest.get(command_queue), atol=tol)
 
     def _test_c2r(
         self,
         context: AbstractContext,
         command_queue: AbstractCommandQueue,
-        N: int,
         shape: Tuple[int, ...],
+        dtype_src: DTypeLike,
+        dtype_dest: DTypeLike,
         padded_shape_src: Tuple[int, ...],
         padded_shape_dest: Tuple[int, ...]
     ) -> None:
         rs = np.random.RandomState(1)
         template = fft.FftTemplate(
-            context, N, shape, np.complex64, np.float32, padded_shape_src, padded_shape_dest)
+            context, 2, shape, dtype_src, dtype_dest, padded_shape_src, padded_shape_dest)
         fn = template.instantiate(command_queue, fft.FftMode.INVERSE)
         fn.ensure_all_bound()
         src = fn.buffer('src')
         dest = fn.buffer('dest')
         signal = rs.standard_normal(shape).astype(np.float32) + 3
-        src.set(command_queue, np.fft.rfftn(signal, axes=(2, 3)).astype(np.complex64))
+        src.set(command_queue, np.fft.rfftn(signal, axes=(-2, -1)).astype(dtype_src))
         fn()
-        expected = signal * shape[2] * shape[3]
-        np.testing.assert_allclose(expected, dest.get(command_queue), rtol=1e-4)
+        expected = signal * shape[2] * shape[3]  # CUFFT does unnormalised FFTs
+        tol = np.finfo(dtype_src).resolution * np.max(np.abs(expected))
+        np.testing.assert_allclose(expected, dest.get(command_queue), atol=tol)
 
     @device_test
     @cuda_test
     def test_r2c_even(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
-        self._test_r2c(context, command_queue, 2, (3, 2, 16, 48), (3, 2, 24, 64), (3, 2, 20, 27))
+        self._test_r2c(context, command_queue,
+                       (3, 2, 16, 48), np.float32, np.complex64, (3, 2, 24, 64), (3, 2, 20, 27))
 
     @device_test
     @cuda_test
     def test_r2c_odd(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
-        self._test_r2c(context, command_queue, 2, (3, 2, 15, 47), (3, 2, 23, 63), (3, 2, 17, 24))
+        self._test_r2c(context, command_queue,
+                       (3, 2, 15, 47), np.float32, np.complex64, (3, 2, 23, 63), (3, 2, 17, 24))
 
     @device_test
     @cuda_test
     def test_c2r_even(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
-        self._test_c2r(context, command_queue, 2, (3, 2, 16, 48), (3, 2, 20, 27), (3, 2, 24, 64))
+        self._test_c2r(context, command_queue,
+                       (3, 2, 16, 48), np.complex64, np.float32, (3, 2, 20, 27), (3, 2, 24, 64))
 
     @device_test
     @cuda_test
     def test_c2r_odd(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
-        self._test_c2r(context, command_queue, 2, (3, 2, 15, 47), (3, 2, 17, 24), (3, 2, 23, 63))
+        self._test_c2r(context, command_queue,
+                       (3, 2, 15, 47), np.complex64, np.float32, (3, 2, 17, 24), (3, 2, 23, 63))
 
     @device_test
     @cuda_test
-    def test_inverse(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
-        rs = np.random.RandomState(1)
-        template = fft.FftTemplate(
-            context, 2, (3, 2, 16, 48), np.complex64, np.complex64,
-            (3, 2, 24, 64), (3, 2, 20, 48))
-        fn = template.instantiate(command_queue, fft.FftMode.INVERSE)
-        fn.ensure_all_bound()
-        src = fn.buffer('src')
-        dest = fn.buffer('dest')
-        src_host = complex_normal(rs, size=src.shape).astype(np.complex64)
-        src.set(command_queue, src_host)
-        fn()
-        expected = np.fft.ifftn(src_host, axes=(2, 3)) * (src.shape[2] * src.shape[3])
-        np.testing.assert_allclose(expected, dest.get(command_queue), rtol=1e-4)
+    def test_d2z(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
+        self._test_r2c(context, command_queue,
+                       (3, 2, 16, 48), np.float64, np.complex128, (3, 2, 24, 64), (3, 2, 20, 27))
+
+    @device_test
+    @cuda_test
+    def test_z2d(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:
+        self._test_c2r(context, command_queue,
+                       (3, 2, 15, 47), np.complex128, np.float64, (3, 2, 17, 24), (3, 2, 23, 63))
+
+    @device_test
+    @cuda_test
+    def test_c2c_forward(
+        self,
+        context: AbstractContext,
+        command_queue: AbstractCommandQueue
+    ) -> None:
+        self._test_c2c_forward(context, command_queue,
+                               (7, 16, 48), np.complex64, (7, 16, 48), (7, 18, 51))
+
+    @device_test
+    @cuda_test
+    def test_c2c_inverse(
+        self,
+        context: AbstractContext,
+        command_queue: AbstractCommandQueue
+    ) -> None:
+        self._test_c2c_inverse(context, command_queue,
+                               (7, 16, 48), np.complex64, (7, 16, 48), (7, 18, 51))
+
+    @device_test
+    @cuda_test
+    def test_z2z_forward(
+        self,
+        context: AbstractContext,
+        command_queue: AbstractCommandQueue
+    ) -> None:
+        self._test_c2c_forward(context, command_queue,
+                               (7, 16, 48), np.complex128, (7, 16, 48), (7, 18, 51))
+
+    @device_test
+    @cuda_test
+    def test_z2z_inverse(
+        self,
+        context: AbstractContext,
+        command_queue: AbstractCommandQueue
+    ) -> None:
+        self._test_c2c_inverse(context, command_queue,
+                               (7, 16, 48), np.complex128, (7, 16, 48), (7, 18, 51))
+
+    @device_test
+    @cuda_test
+    def test_wrong_direction(
+        self,
+        context: AbstractContext,
+        command_queue: AbstractCommandQueue
+    ) -> None:
+        template = fft.FftTemplate(context, 1, (16,), np.float32, np.complex64, (16,), (9,),)
+        with assert_raises_regex(ValueError, 'R2C transform must use FftMode.FORWARD'):
+            template.instantiate(command_queue, fft.FftMode.INVERSE)
+        template = fft.FftTemplate(context, 1, (16,), np.complex64, np.float32, (9,), (16,),)
+        with assert_raises_regex(ValueError, 'C2R transform must use FftMode.INVERSE'):
+            template.instantiate(command_queue, fft.FftMode.FORWARD)
+
+    @device_test
+    @cuda_test
+    def test_bad_dtype_combination(
+        self,
+        context: AbstractContext,
+        command_queue: AbstractCommandQueue
+    ) -> None:
+        with assert_raises_regex(ValueError, 'Invalid combination of dtypes'):
+            fft.FftTemplate(context, 1, (16,), np.float32, np.complex128, (16,), (16,))
+        with assert_raises_regex(ValueError, 'Invalid combination of dtypes'):
+            fft.FftTemplate(context, 1, (16,), np.int32, np.int32, (16,), (16,))
+
+    @device_test
+    @cuda_test
+    def test_length_mismatch(
+        self,
+        context: AbstractContext,
+        command_queue: AbstractCommandQueue
+    ) -> None:
+        with assert_raises_regex(ValueError, 'padded_shape_src and shape'):
+            fft.FftTemplate(context, 1, (16, 16), np.float32, np.complex64, (16,), (16, 16))
+        with assert_raises_regex(ValueError, 'padded_shape_dest and shape'):
+            fft.FftTemplate(context, 1, (16, 16), np.float32, np.complex64, (16, 16), (16,))
+
+    @device_test
+    @cuda_test
+    def test_bad_padding(
+        self,
+        context: AbstractContext,
+        command_queue: AbstractCommandQueue
+    ) -> None:
+        with assert_raises_regex(ValueError, 'Source must not be padded'):
+            fft.FftTemplate(context, 1, (16, 16), np.complex64, np.complex64, (17, 16), (16, 16))
+        with assert_raises_regex(ValueError, 'Destination must not be padded'):
+            fft.FftTemplate(context, 1, (16, 16), np.complex64, np.complex64, (16, 16), (17, 16))

--- a/katsdpsigproc/test/test_percentile.py
+++ b/katsdpsigproc/test/test_percentile.py
@@ -5,6 +5,7 @@ from typing import Tuple, Generator, Optional, Callable, cast
 import numpy as np
 
 from .test_accel import device_test, force_autotune
+from . import complex_normal
 from .. import accel
 from .. import percentile
 from ..abc import AbstractContext, AbstractCommandQueue
@@ -45,7 +46,7 @@ class TestPercentile5:
         if is_amplitude:
             ary = np.abs(rs.randn(R, C)).astype(np.float32)  # note positive numbers required
         else:
-            ary = (rs.randn(R, C) + 1j * rs.randn(R, C)).astype(np.complex64)
+            ary = complex_normal(rs, size=(R, C)).astype(np.complex64)
         src = fn.slots['src'].allocate(fn.allocator)
         dest = fn.slots['dest'].allocate(fn.allocator)
         src.set_async(queue, ary)

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,5 +2,5 @@
 python_version = 3.6
 files = katsdpsigproc, scripts, doc/user/examples
 
-[mypy-appdirs.*,asynctest.*,graphviz.*,katversion.*,mako.*,numba.*,nose.*,pandas.*,pycuda.*,pyopencl.*,scipy.*,skcuda.*]
+[mypy-appdirs.*,asynctest.*,graphviz.*,katversion.*,mako.*,numba.*,nose.*,pandas.*,pycuda.*,pyopencl.*,scipy.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,5 +2,5 @@
 python_version = 3.6
 files = katsdpsigproc, scripts, doc/user/examples
 
-[mypy-appdirs.*,asynctest.*,graphviz.*,katversion.*,mako.*,numba.*,nose.*,pandas.*,pycuda.*,pyopencl.*,scipy.*]
+[mypy-appdirs.*,asynctest.*,graphviz.*,katversion.*,mako.*,numba.*,nose.*,pandas.*,pycuda.*,pyopencl.*,scipy.*,skcuda.*]
 ignore_missing_imports = True


### PR DESCRIPTION
This is based on the FFT implementation in katsdpimager, but using ctypes to interface with CUFFT directly, rather than using scikit-cuda (which has some issues). The unit tests have also been improved.