### PR TITLE
Bump sphinxcontrib-tikz to the latest version

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,5 +1,5 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
 sphinx
-sphinxcontrib-tikz==0.4.8
+sphinxcontrib-tikz==0.4.15
 sphinx-rtd-theme

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -11,7 +11,6 @@ nose
 numba
 pandas
 scipy
-rtd-tikz        # See https://tikz-in-readthedocs.readthedocs.io/
 typing_extensions
 
 sphinx


### PR DESCRIPTION
The old version wasn't working with the latest setuptools, causing
readthedocs builds to break.

Also removed rtd-tikz since it says that it's [not needed any
more](https://github.com/jluttine/tikz-in-readthedocs).
