### PR TITLE
Fix the type of the rank parameter to cufftMakePlanMany64

### DIFF
--- a/katsdpsigproc/fft.py
+++ b/katsdpsigproc/fft.py
@@ -124,7 +124,7 @@ class _Cufft:
             "cufftMakePlanMany64",
             [
                 self.cufftHandle,
-                ctypes.c_longlong,                      # rank
+                ctypes.c_int,                           # rank
                 ctypes.POINTER(ctypes.c_longlong),      # n
                 ctypes.POINTER(ctypes.c_longlong),      # inembed
                 ctypes.c_longlong,                      # istride,


### PR DESCRIPTION
I expect this won't make any difference most 64-bit systems as the value
will be passed in a 64-bit register regardless, but it would probably
break things on 32-bit systems.
