### PR TITLE
Prepare for 1.5.0 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+  python: python3.8
+
 repos:
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 Assorted radio astronomy signal processing routines, with hardware acceleration.
+
+Documentation is available on
+[readthedocs](https://katsdpsigproc.readthedocs.io/).

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+.. rubric:: 1.5.0
+
+- Add :envvar:`KATSDPSIGPROC_TUNE_MATCH` environment variable to control use of
+  partial matches from the autotuning database.
+
 .. rubric:: 1.4.3
 
 - Switching testing from nose to pytest.


### PR DESCRIPTION
A couple of other changes:
- The pre-commit config now forces a Python version, because the pinned numpy version doesn't install on the latest Python versions. I somewhat arbitrarily chose 3.8 because that's what the previous Ubuntu LTS shipped.
- Add a link to readthedocs to the README.