### PR TITLE
Fix a number of DeprecationWarnings reported by pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 asyncio_mode = auto
 # It's utilities for downstream packages, not tests
 addopts = --ignore=src/katsdpsigproc/test
+# Updating the code to fix this warning would break support for older versions
+# of numpy.
+filterwarnings = ignore:.*the `interpolation=` argument to percentile was renamed.*:DeprecationWarning

--- a/test/rfi/test_background.py
+++ b/test/rfi/test_background.py
@@ -46,7 +46,7 @@ def setup() -> None:
 
 
 class TestBackgroundMedianFilterHost:
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         self.background = host.BackgroundMedianFilterHost(3)
 
     def test(self) -> None:

--- a/test/rfi/test_twodflag.py
+++ b/test/rfi/test_twodflag.py
@@ -49,7 +49,7 @@ class TestAsbool:
 
 
 class TestAverageFreq:
-    def setup(self):
+    def setup_method(self):
         self.small_data = np.arange(30, dtype=np.float32).reshape(5, 6, 1).repeat(2, axis=2)
         self.small_flags = np.zeros(self.small_data.shape, np.bool_)
         self.small_flags[3, :, 0] = 1
@@ -158,7 +158,7 @@ def test_time_median():
 class TestMedianAbs:
     """Test :func:`.twodflag._median_abs` and :func:`.twodflag._median_abs_axis0`."""
 
-    def setup(self):
+    def setup_method(self):
         self.data = np.array([[-2.0, -6.0, 4.5], [1.5, 3.3, 0.5]], np.float32)
         self.flags = np.array([[0, 0, 0], [0, 1, 0]], np.uint8)
 
@@ -185,7 +185,7 @@ class TestMedianAbs:
 class TestLinearlyInterpolateNans:
     """Tests for :func:`katsdpsigproc.rfi.twodflag._linearly_interpolate_nans`."""
 
-    def setup(self):
+    def setup_method(self):
         self.y = np.array([np.nan, np.nan, 4.0, np.nan, np.nan, 10.0, np.nan, -2.0, np.nan, np.nan])
         self.expected = np.array([4.0, 4.0, 4.0, 6.0, 8.0, 10.0, 4.0, -2.0, -2.0, -2.0])
 
@@ -289,7 +289,7 @@ class TestBoxGaussianFilter:
 
 
 class TestMaskedGaussianFilter:
-    def setup(self):
+    def setup_method(self):
         self.rs = np.random.RandomState(seed=1)
         shape = (77, 53)
         self.data = self.rs.uniform(size=shape).astype(np.float32)
@@ -337,7 +337,7 @@ class TestGetBackground2D:
     where large regions are flagged.
     """
 
-    def setup(self):
+    def setup_method(self):
         self.shape = (95, 86)
         self.data = np.ones(self.shape, np.float32) * 7.5
         self.flags = np.zeros(self.shape, np.uint8)
@@ -413,7 +413,7 @@ class TestGetBackground2D:
 
 
 class TestSumThreshold:
-    def setup(self):
+    def setup_method(self):
         self.small_data = np.arange(30, dtype=np.float32).reshape(5, 6)
         self.small_flags = np.zeros(self.small_data.shape, np.bool_)
         self.small_flags[3, :] = 1
@@ -489,7 +489,7 @@ class TestSumThreshold:
 class TestSumThresholdFlagger:
     """Tests for :class:`katsdpsigproc.rfi.twodflag.SumThresholdFlagger`."""
 
-    def setup(self):
+    def setup_method(self):
         self.flagger = twodflag.SumThresholdFlagger()
 
     def _make_background(self, shape, rs):

--- a/test/test_accel.py
+++ b/test/test_accel.py
@@ -611,7 +611,7 @@ class TestIOSlot:
 class TestCompoundIOSlot:
     """Tests for :class:`katsdpsigproc.accel.CompoundIOSlot`."""
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         self.dims1 = (
             accel.Dimension(13, min_padded_size=17, alignment=1),
             accel.Dimension(7, min_padded_size=8, alignment=8),
@@ -693,7 +693,7 @@ class TestCompoundIOSlot:
 class TestAliasIOSlot:
     """Tests for :class:`katsdpsigproc.accel.AliasIOSlot`."""
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         self.slot1 = accel.IOSlot((3, 7), np.float32)
         self.slot2 = accel.IOSlot((5, 3), np.complex64)
 
@@ -736,10 +736,10 @@ class TestVisualizeOperation:
         def _run(self) -> None:
             pass
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         self.tmpdir = tempfile.mkdtemp()
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         shutil.rmtree(self.tmpdir)
 
     def test(self, context: AbstractContext, command_queue: AbstractCommandQueue) -> None:

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -95,7 +95,7 @@ class DummyEvent(AbstractEvent):
 
 
 class TestResource:
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         self.completed = queue.Queue()      # type: queue.Queue[resource.ResourceAllocation[int]]
 
     async def _run_frame(self, acq: resource.ResourceAllocation[int],
@@ -156,11 +156,12 @@ class TestResource:
 
 
 class TestJobQueue:
-    def setup(self) -> None:
+    @pytest.fixture(autouse=True)
+    def setup(self, event_loop) -> None:
         self.jobs = resource.JobQueue()
-        self.finished = [asyncio.Future()
+        self.finished = [event_loop.create_future()
                          for i in range(5)]      # type: List[asyncio.Future[int]]
-        self.unfinished = [asyncio.Future()
+        self.unfinished = [event_loop.create_future()
                            for i in range(5)]    # type: List[asyncio.Future[int]]
         for i, future in enumerate(self.finished):
             future.set_result(i)


### PR DESCRIPTION
These are all in the test code rather than the library itself:

- Rename `setup` functions to `setup_method` (`setup` is supported for
  pytest for nose compatibility, but is deprecated), and similarly for
  `teardown`.
- Use `event_loop.create_future()` instead of `asyncio.Future()` in
  non-async setup code.
- Suppress a numpy deprecation warning where the replacement would only
  work in newish versions of numpy.
