### PR TITLE
fix SQL query build logic

### DIFF
--- a/src/katsdpsigproc/tune.py
+++ b/src/katsdpsigproc/tune.py
@@ -136,8 +136,6 @@ def _query(
     query_args = []
     first = True
     for key, value in keys.items():
-        if key == 'arg_param' and value is None:
-            continue
         if first:
             query += " WHERE"
         else:

--- a/src/katsdpsigproc/tune.py
+++ b/src/katsdpsigproc/tune.py
@@ -132,11 +132,13 @@ def _db_keys(fn: _TuningFunc, args: Sequence, kwargs: Mapping) -> Dict[str, Any]
 def _query(
     conn: sqlite3.Connection, tablename: str, keys: Mapping[str, Any]
 ) -> Optional[sqlite3.Row]:
-    query = f"SELECT * FROM {tablename} WHERE"
+    query = f"SELECT * FROM {tablename}"
     query_args = []
     first = True
     for key, value in keys.items():
-        if not first:
+        if first:
+            query += " WHERE"
+        else:
             query += " AND"
         first = False
         query += f" {key}=?"

--- a/src/katsdpsigproc/tune.py
+++ b/src/katsdpsigproc/tune.py
@@ -136,6 +136,8 @@ def _query(
     query_args = []
     first = True
     for key, value in keys.items():
+        if key == 'arg_param' and value is None:
+            continue
         if first:
             query += " WHERE"
         else:

--- a/test/test_tune.py
+++ b/test/test_tune.py
@@ -18,7 +18,7 @@
 
 import threading
 from unittest import mock
-from typing import Any, Generator, Mapping, NoReturn
+from typing import Any, Generator, Mapping, NoReturn, Optional
 
 import pytest
 import sqlite3
@@ -104,7 +104,7 @@ class TestAutotuner:
 
     @classmethod
     @tune.autotuner(test={'a': 3, 'b': -1})
-    def autotune(cls, context: AbstractContext, param: str) -> Mapping[str, Any]:
+    def autotune(cls, context: AbstractContext, param: Optional[str]) -> Mapping[str, Any]:
         return cls.autotune_mock(context, param)
 
     @mock.patch('katsdpsigproc.tune._close_db')

--- a/test/test_tune.py
+++ b/test/test_tune.py
@@ -99,6 +99,7 @@ class TestAutotuner:
         # autotuner decorator, and hence autotune_mock has to be at class
         # scope. But we want it reset for each test.
         self.autotune_mock.reset()
+        self.autotune_mock.side_effect = None
         yield
         self.autotune_mock.reset()
 
@@ -184,9 +185,6 @@ class TestAutotuner:
             context.device.name = 'z'
             ret = self.autotune(context, 'xyz')
             assert ret == tuning_1 or ret == tuning_2
-
-            # manually reset autotune_mock to no longer raise RuntimeError
-            self.autotune_mock.side_effect = None
 
     @mock.patch('katsdpsigproc.tune._close_db')
     @mock.patch('katsdpsigproc.tune._open_db')


### PR DESCRIPTION
Previously, a dangling `WHERE` clause caused some SQL queries to fail. This fixes the query build logic to only insert a `WHERE` clause when the table contains parameters.