### PR TITLE
Allow OperationSequence to have a mix of command queues

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+.. rubric:: Development version
+
+- Add `relaxed_command_queues` option to :class:`~.OperationSequence`.
+
 .. rubric:: 1.6.1
 
 - Fix a race condition that sometimes caused events passed to


### PR DESCRIPTION
This will enable use cases where some of the operations can safely run in parallel, with the subclass handling synchronisation between the queues. It requires opt-in, so that the existing sanity check remains the default.