### PR TITLE
Use importlib.resources instead of pkg_resources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,5 +14,6 @@ repos:
         pass_filenames: false
         additional_dependencies: [
           "numpy==1.20.1",
-          "pytest==6.2.5"
+          "pytest==6.2.5",
+          "importlib_resources==5.12.0",
         ]

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+.. rubric:: Development version
+
+- Remove dependency on deprecated :mod:`pkg_resources` and use
+  :mod:`importlib.resources` instead.
+
 .. rubric:: 1.6.1
 
 - Fix a race condition that sometimes caused events passed to

--- a/doc/user/kernels.rst
+++ b/doc/user/kernels.rst
@@ -93,8 +93,12 @@ function. Usage might look like
 
   program = accel.build(
       ctx, 'my_kernel.mako', {'block': block},
-      extra_dirs=[pkg_resources.resource_filename(__name__, '')]
+      extra_dirs=[importlib.resources.files('packagename')]
   )
+
+Note that using :func:`importlib.resources.files` like this is hacky, as it
+will only work if it returns a real filesystem path rather than an arbitrary
+loader.
 
 The dictionary argument provides variables that can be expanded in the
 template, using ``${varname}`` syntax.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 
 appdirs
 decorator
+importlib-resources
 mako
 numba
 numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ packages = find:
 install_requires =
     appdirs
     decorator
+    importlib-resources; python_version < "3.9"
     mako
     numba >= 0.36.1   # Older versions have bugs in median functions
     numpy >= 1.10

--- a/src/katsdpsigproc/accel.py
+++ b/src/katsdpsigproc/accel.py
@@ -50,7 +50,10 @@ except ImportError:
 import mako.lexer
 from mako.template import Template
 from mako.lookup import TemplateLookup
-import pkg_resources
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 
 from .abc import (AbstractContext, AbstractDevice, AbstractCommandQueue,  # noqa: F401
                   AbstractTuningCommandQueue, AbstractProgram)
@@ -124,8 +127,8 @@ class LinenoLexer(mako.lexer.Lexer):
         return ''.join(out)
 
 
-def _make_lookup(extra_dirs: List[str]) -> TemplateLookup:
-    dirs = extra_dirs + [pkg_resources.resource_filename(__name__, '')]
+def _make_lookup(extra_dirs: List[Union[str, os.PathLike]]) -> TemplateLookup:
+    dirs = extra_dirs + [importlib_resources.files("katsdpsigproc")]
     return TemplateLookup(dirs, lexer_cls=LinenoLexer, strict_undefined=True)
 
 
@@ -135,7 +138,7 @@ _lookup = _make_lookup([])
 
 def build(context: AbstractContext, name: str,
           render_kws: Optional[Mapping[str, Any]] = None,
-          extra_dirs: Optional[List[str]] = None,
+          extra_dirs: Optional[List[Union[str, os.PathLike]]] = None,
           extra_flags: Optional[List[str]] = None,
           source: Optional[str] = None) -> AbstractProgram:
     """Build a source module from a mako template.


### PR DESCRIPTION
The latter is deprecated. On Python <3.9, use the backport (importlib_resources).