### PR TITLE
Add Operation.ensure_bound

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 
 .. rubric:: Development version
 
+- Add :meth:`.Operation.ensure_bound`.
 - Remove dependency on deprecated :mod:`pkg_resources` and use
   :mod:`importlib.resources` instead.
 

--- a/src/katsdpsigproc/accel.py
+++ b/src/katsdpsigproc/accel.py
@@ -1523,6 +1523,12 @@ class Operation(ABC):
                 raise TypeError(f'Slot {slot} is not an IOSlot')
             slot.bind(buffer)
 
+    def ensure_bound(self, name: str) -> None:
+        """Make sure that a specific slot has a buffer bound, allocating if necessary."""
+        slot = self.slots[name]
+        if not slot.is_bound():
+            slot.allocate(self.allocator)
+
     def ensure_all_bound(self) -> None:
         """Make sure that all slots have a buffer bound, allocating if necessary."""
         for slot in self.slots.values():


### PR DESCRIPTION
This allows for more fine-grained control than `ensure_all_bound`.