### PR TITLE
Add KATSDPSIGPROC_TUNE_DB environment variable

### DIFF
--- a/doc/user/autotune.rst
+++ b/doc/user/autotune.rst
@@ -162,6 +162,9 @@ the device driver, then platform, then device name. If no match is found,
 autotuning will proceed. If `KATSDPSIGPROC_TUNE_MATCH` is set to "exact" (or
 anything else), default behaviour will proceed.
 
+It is also possible to override the location of the tuning database by
+setting the environment variable :envvar:`KATSDPSIGPROC_TUNE_DB`.
+
 .. _autotune-testing:
 
 Testing

--- a/src/katsdpsigproc/tune.py
+++ b/src/katsdpsigproc/tune.py
@@ -234,17 +234,12 @@ def _save(
 
 
 def _open_db() -> sqlite3.Connection:
-    cache_dir = appdirs.user_cache_dir("katsdpsigproc", "ska-sa")
-    try:
-        os.makedirs(cache_dir)
-    except OSError:
-        # This happens if the directory already exists. If we failed
-        # to create it, the database open will fail.
-        pass
-
-    cache_file = os.path.join(cache_dir, "tuning.db")
-    conn = sqlite3.connect(cache_file)
-    return conn
+    cache_file = os.getenv("KATSDPSIGPROC_TUNE_DB")
+    if cache_file is None:
+        cache_dir = appdirs.user_cache_dir("katsdpsigproc", "ska-sa")
+        os.makedirs(cache_dir, exist_ok=True)
+        cache_file = os.path.join(cache_dir, "tuning.db")
+    return sqlite3.connect(cache_file)
 
 
 def _close_db(conn: sqlite3.Connection) -> None:


### PR DESCRIPTION
It allows the location of the tuning database to be overridden.