### PR TITLE
Eliminate deprecated numba.generated_jit

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+.. rubric:: Development version
+
+- Remove use of deprecated :func:`numba.generated_jit` decorator.
+
 .. rubric:: 1.7.0
 
 - Add :meth:`.Operation.ensure_bound`.

--- a/src/katsdpsigproc/rfi/twodflag.py
+++ b/src/katsdpsigproc/rfi/twodflag.py
@@ -54,7 +54,7 @@ def _asbool(data):
         return data.astype(np.bool_)
 
 
-@numba.extending.overload(_asbool, jit_options=dict(nopython=True, nogil=True))
+@numba.extending.overload(_asbool, jit_options=dict(nogil=True))
 def _overload_asbool(data):
     if (isinstance(data.dtype, numba.types.Boolean)
             or (isinstance(data.dtype, numba.types.Integer) and data.dtype.bitwidth == 8)):


### PR DESCRIPTION
See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-generated-jit for an explanation.