### PR TITLE
Improve exception message for unknown slot

### DIFF
--- a/src/katsdpsigproc/accel.py
+++ b/src/katsdpsigproc/accel.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2014-2021, National Research Foundation (SARAO)
+# Copyright (c) 2014-2023, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -1565,7 +1565,7 @@ class Operation(ABC):
             try:
                 slot = self.hidden_slots[name]
             except KeyError:
-                raise KeyError('no slot named ' + name)
+                raise KeyError('no slot named ' + name) from None
         if isinstance(slot, IOSlot):
             if slot.buffer is None:
                 raise ValueError('slot ' + name + ' has no buffer bound')


### PR DESCRIPTION
It was previously reporting a whole chain of exceptions, only the last of which was actually relevant to the user.