### PR TITLE
Fix .readthedocs.yml for new requirement

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,6 @@
 version: 2
+sphinx:
+  configuration: doc/conf.py
 build:
   os: ubuntu-22.04
   tools:


### PR DESCRIPTION
See https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/