### PR TITLE
Update fft.py according to CUDA 12.9 cuFFT change

### DIFF
--- a/src/katsdpsigproc/fft.py
+++ b/src/katsdpsigproc/fft.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2021, National Research Foundation (SARAO)
+# Copyright (c) 2021, 2025 National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
This was discovered during work for NGC-1682 in supporting the latest Blackwell NVIDIA GPUs (RTX 5070).
- https://docs.nvidia.com/cuda/archive/12.9.0/cuda-toolkit-release-notes/index.html#cufft-release-12-9

I'm not actually sure of the wording I've added, so I've mostly created this PR for explicit attention.