### PR TITLE
SPR1-2373: Support INT_MIN and friends on CUDA

### DIFF
--- a/src/katsdpsigproc/port.mako
+++ b/src/katsdpsigproc/port.mako
@@ -50,6 +50,7 @@ DEVICE_FN ${type}4 make_${type}4(${type} x, ${type} y, ${type} z, ${type} w)
 
 #include <math.h>
 #include <float.h>
+#include <limits.h>
 #include <stdio.h>
 
 /* System headers may provide some of these, but it's OS dependent. It's


### PR DESCRIPTION
OpenCL already exposes constants like INT_MIN and INT_MAX.

It looks like CUDA already sneaks in INT_MIN somewhere, but this is safer.

The main use case is the new missing data indicator in the GPU CBF, which assigns the (32-bit) value INT_MIN to the real part of incomplete correlator data. See ska-sa/katsdpingest#373 for more details.